### PR TITLE
Update GitHub link in home navigation

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -32,19 +32,20 @@ const Navbar = () => {
             <span className="text-xl font-medium tracking-tight">aiux</span>
           </Link>
 
-          {/* GitHub Links */}
+          {/* Navigation Links */}
           <div className="flex items-center gap-4">
-            <a
-              href="https://github.com/imsaif/aiex"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/"
               className="flex items-center gap-2 px-3 py-2 text-text-primary hover:text-accent-primary transition-colors duration-200 rounded-lg hover:bg-accent-subtle"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-5 h-5">
+                <rect x="3" y="3" width="7" height="7" />
+                <rect x="14" y="3" width="7" height="7" />
+                <rect x="14" y="14" width="7" height="7" />
+                <rect x="3" y="14" width="7" height="7" />
               </svg>
-              <span className="hidden sm:inline text-sm font-medium">GitHub</span>
-            </a>
+              <span className="hidden sm:inline text-sm font-medium">Patterns</span>
+            </Link>
             <Link
               href="/guides"
               className="flex items-center gap-2 px-3 py-2 text-text-primary hover:text-accent-primary transition-colors duration-200 rounded-lg hover:bg-accent-subtle"


### PR DESCRIPTION
Changed the navigation bar to show "Patterns" instead of "GitHub" link, allowing users to navigate back to the patterns page from the guides page. Replaced GitHub icon with a grid icon to better represent patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)