### PR TITLE
docs: add architecture decision records and refresh stale architecture doc

### DIFF
--- a/docs/adr/0001-nextjs-app-router.md
+++ b/docs/adr/0001-nextjs-app-router.md
@@ -1,0 +1,45 @@
+# 0001 — Next.js 15 App Router as the framework
+
+**Status:** Accepted
+
+## Context
+
+This is a content site whose entire value depends on being discovered through
+search. Around 36 AI design patterns, plus guides, a newsletter archive, and a
+paid audit funnel, all need to be reliably crawlable and fast to load. SEO and
+Core Web Vitals are first-order product requirements, not afterthoughts — the
+project maintains a Lighthouse/LHCI budget and a documented Web Vitals incident
+log to prove it.
+
+We also wanted strong TypeScript support and a single codebase that could host
+both static content pages and a handful of dynamic API routes (newsletter
+subscribe/publish, audit analysis, health checks).
+
+## Decision
+
+Use **Next.js 15 with the App Router** (React 19, Turbopack in dev), rendering
+content pages with SSG/SSR and serving dynamic behavior through App Router API
+routes.
+
+## Alternatives considered
+
+- **Plain React SPA (Vite/CRA).** Rejected. Client-only rendering is hostile to
+  crawlers and ships a worse initial load — disqualifying for a search-driven
+  content site.
+- **Remix.** Strong SSR story, but a smaller ecosystem and weaker first-class
+  hosting integration than Next + Vercel at the time. No compelling advantage
+  for a content-first site.
+- **A static-site generator (Astro, Eleventy, Hugo).** Excellent for pure
+  content, but we also need real server-side API routes (subscribe, audit
+  funnel, crons). A SSG-only tool would force a second backend.
+
+## Consequences
+
+- **Buys us:** server-rendered, crawlable pages; built-in image optimization;
+  API routes co-located with the frontend; tight Vercel integration (see ADR
+  0003); a large ecosystem and React 19 features.
+- **Costs us:** App Router complexity (server vs. client components, caching/ISR
+  semantics — the cause of at least one cached-degraded-page incident, logged in
+  `.claude/rules/newsletter-and-infra.md`); framework lock-in to Next conventions;
+  exposure to Next's faster release cadence.
+</content>

--- a/docs/adr/0002-content-as-code-zod.md
+++ b/docs/adr/0002-content-as-code-zod.md
@@ -1,0 +1,47 @@
+# 0002 — Content-as-code with Zod, not a CMS
+
+**Status:** Accepted
+
+## Context
+
+The core content of the site is ~36 design patterns, each a rich, structured
+object: description, code examples, interactive demo wiring, real-world
+examples, guidelines, considerations, and Figma prompts. This content is
+authored by a very small team and changes alongside the code that renders it.
+
+We needed the content to be (1) strongly typed so the rendering components can
+rely on its shape, (2) versioned and reviewable, and (3) cheap to operate.
+
+## Decision
+
+Store content **as TypeScript modules in the repo**, one directory per pattern
+under `src/data/patterns/patterns/`, aggregated through a central registry
+(`src/data/patterns.ts`) and validated at load time against **Zod** schemas
+(`src/schemas/`). Components consume it through React Context
+(`PatternProvider` + `usePatterns`/`usePattern` hooks).
+
+## Alternatives considered
+
+- **Headless CMS (Contentful, Sanity, Strapi).** Rejected for now. Adds cost, a
+  network dependency, and a sync/caching layer, and weakens end-to-end type
+  safety. Content and rendering code change together here, so a separate content
+  service buys little. (`docs/architecture.md` still lists CMS integration as a
+  *future* possibility — this was a deliberate "start simple" call, not an
+  oversight.)
+- **Markdown/MDX files.** Good for prose, awkward for the deeply structured,
+  multi-field pattern objects with typed code-example and demo references.
+- **A database for content.** Overkill for content that is naturally static,
+  rarely changes outside of code edits, and benefits from build-time rendering.
+  (We *do* use a database — but only for genuinely dynamic data; see ADR 0005.)
+
+## Consequences
+
+- **Buys us:** full TypeScript type safety from authoring to render; Zod
+  validation catches malformed content at load/build; content is git-versioned
+  and code-reviewed; zero CMS cost and no runtime content fetch; pages render
+  statically.
+- **Costs us:** authoring requires a code edit and deploy (no non-technical
+  editor UI); large content sets live in the bundle/build rather than a queryable
+  store; a future pivot to user-generated or editor-managed content would mean
+  introducing a CMS or DB-backed content layer.
+</content>

--- a/docs/adr/0003-vercel-hosting.md
+++ b/docs/adr/0003-vercel-hosting.md
@@ -1,0 +1,35 @@
+# 0003 — Vercel for hosting
+
+**Status:** Accepted
+
+## Context
+
+We chose Next.js (ADR 0001) and needed a host that runs it with minimal
+operational overhead for a small team, gives us a global CDN for a
+search-driven content site, and provides the performance tooling we care about.
+Cost matters — the project runs on free/hobby tiers wherever possible.
+
+## Decision
+
+Deploy on **Vercel** (production domain `aiuxdesign.guide`), using Git-push
+deploys, edge CDN delivery, serverless functions for API routes, and Vercel's
+`@vercel/analytics`, `@vercel/speed-insights`, and `@vercel/og` packages.
+
+## Alternatives considered
+
+- **Netlify / Cloudflare Pages.** Capable Next hosts, but Vercel is the
+  first-party Next.js platform — new framework features land there first and
+  config is closest to zero.
+- **Self-managed (VPS, Docker, AWS).** Rejected. Far more operational burden
+  (scaling, TLS, CDN, CI/CD) than a small team should carry for this workload.
+
+## Consequences
+
+- **Buys us:** zero-config Next deploys; global edge CDN; preview deploys per
+  PR; built-in Web Vitals/analytics and OG image generation; generous free tier.
+- **Costs us:** platform lock-in (some features assume Vercel primitives) and
+  hard **Hobby-tier limits** that have actively shaped the architecture — the
+  60s function timeout and unreliable Hobby cron drove the move to an external
+  cron trigger (see ADR 0007) and forced newsletter generation onto a faster
+  model. These incidents are logged in `.claude/rules/newsletter-and-infra.md`.
+</content>

--- a/docs/adr/0004-tailwind-design-tokens.md
+++ b/docs/adr/0004-tailwind-design-tokens.md
@@ -1,0 +1,41 @@
+# 0004 — Tailwind CSS v4 with enforced design tokens
+
+**Status:** Accepted
+
+## Context
+
+A small team needs to ship UI quickly while keeping a visually coherent brand
+across dozens of pattern pages, demos, and marketing surfaces. Without a large
+team of reviewers to police consistency, the discipline a design system usually
+relies on has to come from automation instead.
+
+## Decision
+
+Use **Tailwind CSS v4** (utility-first) on top of a **custom design-token
+system**, and **enforce the token contract automatically**: a brand validator
+(`scripts/analysis/brand-validator.js`) runs as a Husky pre-commit hook and
+*blocks* commits that introduce raw hex colors, off-grid spacing, ad-hoc
+z-index, or non-token radii. Details live in `.claude/rules/design-system.md`
+and `docs/DESIGN_SYSTEM_ENFORCEMENT.md`.
+
+## Alternatives considered
+
+- **CSS-in-JS (styled-components, Emotion).** Rejected. Runtime cost and weaker
+  alignment with React Server Components; Tailwind keeps styling static and fast.
+- **Plain CSS / CSS Modules.** Workable, but slower to author and far harder to
+  keep consistent without strong conventions and tooling.
+- **A prebuilt component kit (MUI, Chakra) as the design foundation.** Rejected
+  as the base layer — too opinionated to carry a custom brand cleanly. (Some
+  utility libraries like `antd` and `@heroicons/react` are used selectively, but
+  the brand layer is our own tokens.)
+
+## Consequences
+
+- **Buys us:** fast UI development; brand consistency enforced by a machine, not
+  by reviewer vigilance; styling stays static and SSR-friendly; tokens give a
+  single source of truth for color/spacing/scale.
+- **Costs us:** a real learning curve and process friction — the pre-commit gate
+  will reject non-conforming code, so contributors must work through tokens; a
+  migration backlog exists for older code predating the contract (tracked in the
+  design-system rule).
+</content>

--- a/docs/adr/0005-prisma-neon-postgres.md
+++ b/docs/adr/0005-prisma-neon-postgres.md
@@ -1,0 +1,46 @@
+# 0005 — Prisma + Neon Postgres for persistence
+
+**Status:** Accepted
+
+## Context
+
+The static content is code (ADR 0002), but two features need genuine persistent
+state: the **newsletter** (subscribers, generated drafts, publish status) and
+operational data feeding the funnel and monitoring (e.g. audit samples, real-user
+Web Vitals metrics). This was added when those features required it — not as
+upfront architecture.
+
+We wanted a datastore that fits the existing TypeScript/Zod world, stays on a
+free tier, and works cleanly with Vercel's serverless functions.
+
+## Decision
+
+Use **Postgres hosted on Neon**, accessed through **Prisma ORM** (client
+generated to `src/generated/prisma`, `prisma generate` wired into `postinstall`).
+The local database is the source of truth for subscribers and is mirrored to
+Beehiiv (see ADR 0006).
+
+## Alternatives considered
+
+- **No database (keep everything static/in-repo).** Insufficient — subscribers
+  and generated newsletter drafts are inherently dynamic, per-user state.
+- **A NoSQL/document store (Mongo, Firestore).** Rejected. The data is
+  relational (subscribers, drafts, metrics) and benefits from Postgres
+  constraints; Prisma's typed client matches our type-safety priority better.
+- **Supabase / PlanetScale / Vercel Postgres.** All viable. Neon was chosen for
+  serverless Postgres with scale-to-zero on a free tier; Prisma keeps us
+  portable across Postgres providers if that changes.
+- **Raw SQL or a query builder (Kysely).** Prisma's generated, typed client and
+  migrations gave better DX for a small team than hand-managed SQL.
+
+## Consequences
+
+- **Buys us:** typed, relational persistence consistent with the rest of the
+  stack; migrations and a generated client; serverless-friendly hosting that
+  sleeps when idle.
+- **Costs us:** Neon free-tier compute can auto-suspend, which interacts with
+  cron cadence (a `*/5` health check was dialed back to hourly so Neon could
+  sleep — see `.claude/rules/newsletter-and-infra.md`); serverless + Prisma needs
+  care around connection pooling; transient DB errors on cached pages must
+  re-throw rather than silently fall back (a logged incident).
+</content>

--- a/docs/adr/0006-beehiiv-resend-email.md
+++ b/docs/adr/0006-beehiiv-resend-email.md
@@ -1,0 +1,49 @@
+# 0006 — Beehiiv + Resend for email
+
+**Status:** Accepted
+
+## Context
+
+The product needs two distinct kinds of email: **newsletter broadcasts** to
+subscribers (an audience product, with growth/automation tooling) and
+**transactional** messages (audit reports to a single user, admin alerts, cron
+failure notices). These have different volumes, deliverability needs, and
+tooling needs, and the project runs on free tiers.
+
+## Decision
+
+Split the two concerns:
+
+- **Beehiiv (free tier)** owns the subscriber audience: subscriber sync, welcome
+  emails via Automations (keyed on a `signup_source` custom field), and
+  newsletter delivery. Because Beehiiv's free/Launch tier has no Posts API,
+  broadcast delivery is intentionally **manual** — an admin copies generated HTML
+  from our admin UI into a new Beehiiv post.
+- **Resend (free tier)** owns transactional email (audit reports, admin
+  watchdog/cron alerts). Volume is ~150/month, well under the 3,000/month cap.
+
+No transactional sends go directly to subscribers — every subscriber-facing
+email is a Beehiiv automation or broadcast. Full details in
+`.claude/rules/newsletter-and-infra.md`.
+
+## Alternatives considered
+
+- **One provider for everything (e.g. all-Resend, or all-Mailchimp).** Rejected.
+  Transactional ESPs lack audience/newsletter-growth tooling; newsletter
+  platforms are poor at one-off transactional mail. The two jobs are genuinely
+  different.
+- **Self-hosted/SMTP (SES + own templates).** Rejected. Deliverability,
+  suppression, and subscriber management would all be ours to build and babysit.
+- **Paid Beehiiv tier for Posts API automation.** Deferred on cost — manual
+  compose is an acceptable trade at current volume.
+
+## Consequences
+
+- **Buys us:** the right tool for each job on free tiers; Beehiiv's growth and
+  automation features for the audience; reliable transactional delivery via
+  Resend; clear separation of concerns.
+- **Costs us:** a **manual step** in newsletter publishing (copy HTML → paste
+  into Beehiiv → send) that can't be automated until a paid Beehiiv tier; two
+  providers plus the local DB to keep in sync (subscriber mirroring); free-tier
+  caps to stay under.
+</content>

--- a/docs/adr/0007-external-cron.md
+++ b/docs/adr/0007-external-cron.md
@@ -1,0 +1,41 @@
+# 0007 — External cron (cron-job.org), not Vercel cron
+
+**Status:** Accepted
+
+## Context
+
+Several jobs run on a schedule: daily and weekly newsletter generation, an
+hourly audit-funnel health monitor, and a daily field Web Vitals check. The site
+is hosted on Vercel's Hobby tier (ADR 0003), which offers built-in cron — but in
+practice Hobby crons did **not** fire reliably (observed Jan–Mar 2026), and when
+both Vercel cron and an external trigger were active they raced, causing silent
+"every other day" newsletter failures.
+
+## Decision
+
+Use **cron-job.org** (free) as the **sole** external trigger. It calls our
+App Router cron endpoints over HTTPS with an `Authorization: Bearer
+<CRON_SECRET>` header. `vercel.json` must **not** contain a `crons` block —
+this was removed and must not be re-added. The full schedule and the incident
+history are documented in `.claude/rules/newsletter-and-infra.md`.
+
+## Alternatives considered
+
+- **Vercel Hobby cron.** Rejected — unreliable execution on Hobby tier, and the
+  root cause of duplicate-run failures when combined with any other trigger.
+- **Upgrade to Vercel Pro for reliable cron.** Deferred on cost; an external
+  trigger solves it for free.
+- **A dedicated scheduler/queue (GitHub Actions schedule, Upstash QStash,
+  Inngest).** Viable and worth revisiting if scheduling needs grow, but
+  cron-job.org is the simplest thing that works for a handful of HTTP triggers.
+
+## Consequences
+
+- **Buys us:** reliable scheduled execution on free infrastructure; a single,
+  unambiguous trigger source (no races).
+- **Costs us:** an external dependency that lives outside the repo and Vercel
+  dashboard (its config and the `CRON_SECRET` must be kept in sync with
+  production); the 60s Vercel function timeout still bounds each job, which is why
+  newsletter generation uses a fast model and responds via `after()`. **Do not
+  re-add `crons` to `vercel.json`** — doing so reintroduces the duplicate-run bug.
+</content>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+# Architecture Decision Records (ADRs)
+
+This directory records the **why** behind the major technical choices in this
+project — the stack, the data model, and the infrastructure. Each record is a
+short, standalone document that captures the decision, the context that drove
+it, the alternatives weighed, and the trade-offs accepted.
+
+These are deliberately written *after the fact* for decisions that were made
+implicitly. They reflect the logic the codebase actually embodies, drawn from
+`docs/technical.md`, the `.claude/rules/` incident logs, and `package.json`.
+Going forward, add a new ADR whenever you make a decision that future-you would
+want explained.
+
+## Format
+
+Each ADR is a numbered Markdown file (`NNNN-short-title.md`) with this shape:
+
+- **Status** — Accepted / Superseded / Deprecated
+- **Context** — the forces and constraints at play
+- **Decision** — what we chose
+- **Alternatives considered** — what we didn't choose, and why
+- **Consequences** — what this buys us, and what it costs
+
+## Index
+
+| #    | Decision                                                        | Status   |
+|------|-----------------------------------------------------------------|----------|
+| 0001 | [Next.js 15 App Router as the framework](./0001-nextjs-app-router.md) | Accepted |
+| 0002 | [Content-as-code with Zod, not a CMS](./0002-content-as-code-zod.md)  | Accepted |
+| 0003 | [Vercel for hosting](./0003-vercel-hosting.md)                  | Accepted |
+| 0004 | [Tailwind CSS v4 with enforced design tokens](./0004-tailwind-design-tokens.md) | Accepted |
+| 0005 | [Prisma + Neon Postgres for persistence](./0005-prisma-neon-postgres.md) | Accepted |
+| 0006 | [Beehiiv + Resend for email](./0006-beehiiv-resend-email.md)    | Accepted |
+| 0007 | [External cron (cron-job.org), not Vercel cron](./0007-external-cron.md) | Accepted |
+</content>
+</invoke>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,9 @@
 # Architecture Overview
 
+> **Why this stack?** This document describes *what* the architecture is. For the
+> *why* behind each major choice — and the alternatives considered — see the
+> [Architecture Decision Records](./adr/README.md).
+
 ## 🏗️ System Architecture
 
 The AI Design Patterns project is built using modern web technologies with a focus on performance, maintainability, and developer experience.
@@ -46,24 +50,33 @@ The AI Design Patterns project is built using modern web technologies with a foc
 
 ### Frontend Technologies
 - **React 19**: Latest React with concurrent features
-- **TypeScript 5.7**: Type safety and better DX
-- **Tailwind CSS 3.4**: Utility-first styling
+- **TypeScript 5**: Type safety and better DX (strict mode)
+- **Tailwind CSS v4**: Utility-first styling over an enforced design-token system
 - **Framer Motion**: Animation library
-- **Lucide React**: Icon library
+- **Heroicons / Lobehub icons**: Icon libraries
+- **Fuse.js**: Client-side fuzzy search
 
 ### Development Tools
-- **Jest**: Testing framework
-- **React Testing Library**: Component testing
+- **Jest + React Testing Library**: Unit/component testing
+- **Playwright**: End-to-end testing
 - **ESLint**: Code linting
 - **Prettier**: Code formatting
-- **Husky**: Git hooks
-- **Turbo**: Build optimization
+- **Husky + lint-staged**: Git hooks (incl. the design-token brand validator)
+- **Turbopack**: Dev build tooling
+- **Lighthouse / LHCI**: Performance budgets
 
 ### Data Management
 - **Zod**: Schema validation
-- **React Context**: State management
+- **React Context**: State management for static content
 - **Local Storage**: User preferences
-- **Static Data**: Pattern definitions
+- **Static Data (content-as-code)**: Pattern definitions live as typed TS modules ([ADR 0002](./adr/0002-content-as-code-zod.md))
+
+### Persistence & Services (dynamic features)
+- **Prisma ORM + Postgres (Neon)**: Newsletter subscribers, drafts, and operational data ([ADR 0005](./adr/0005-prisma-neon-postgres.md))
+- **Beehiiv**: Subscriber audience + newsletter delivery ([ADR 0006](./adr/0006-beehiiv-resend-email.md))
+- **Resend**: Transactional email (audit reports, admin/cron alerts)
+- **Anthropic SDK**: Powers the audit and content-generation tooling
+- **cron-job.org**: External scheduler for newsletter/health/vitals jobs ([ADR 0007](./adr/0007-external-cron.md))
 
 ## 📁 Project Structure
 
@@ -323,14 +336,18 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 ## 🔮 Future Architecture Plans
 
+> **Note:** Some items once listed here as "future" already shipped. A
+> PostgreSQL database (Prisma + Neon) is in production for the newsletter and
+> operational data — see [ADR 0005](./adr/0005-prisma-neon-postgres.md). Pattern
+> content remains intentionally code-based rather than CMS-backed; the trade-off
+> is documented in [ADR 0002](./adr/0002-content-as-code-zod.md).
+
 ### Planned Enhancements
 
-1. **API Layer**: RESTful API for pattern data
-2. **Database**: PostgreSQL for dynamic content
-3. **Authentication**: User accounts and favorites
-4. **CMS Integration**: Content management system
-5. **AI Features**: Pattern recommendations
-6. **Internationalization**: Multi-language support
+1. **Authentication**: User accounts and favorites
+2. **AI Features**: Pattern recommendations
+3. **Internationalization**: Multi-language support
+4. **CMS Integration**: Only if content authoring moves to non-technical editors (see ADR 0002)
 
 ### Scalability Considerations
 

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -41,6 +41,10 @@
 
 ## Architecture Decisions
 
+> Full Architecture Decision Records — with context, alternatives considered, and
+> trade-offs — now live in [`docs/adr/`](./adr/README.md). The summaries below are
+> kept for quick reference; the ADRs are the source of truth.
+
 ### Current Decisions
 1. **Next.js Framework**
    - Reason: Provides excellent TypeScript support and server-side rendering


### PR DESCRIPTION
Add docs/adr/ with 7 ADRs documenting the why behind the stack (Next.js,
content-as-code/Zod, Vercel, Tailwind+design tokens, Prisma/Neon, Beehiiv+Resend,
external cron), each with context, alternatives, and trade-offs.

Refresh docs/architecture.md: correct stale versions (Tailwind v4, TS 5), add
the persistence/services layer, and fix the 'future' section that listed Postgres
as not-yet-shipped. Link technical.md and architecture.md to the ADRs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PgU2bHsnexko2dFRoq3EbJ