### PR TITLE
Fix stale audit-flow E2E test (post-redesign paywall contract)

### DIFF
--- a/e2e/audit-flow.spec.ts
+++ b/e2e/audit-flow.spec.ts
@@ -21,8 +21,17 @@ test.describe('audit funnel — happy path', () => {
     // No per-iteration content assertion — `runOneAudit` already awaited
     // the analyze response; count persistence is verified at the end.
 
-    // After the free audit completes, the unlock modal auto-opens
-    // (AuditClient defers ~600ms before firing).
+    // The redesigned results view deliberately does NOT auto-open the unlock
+    // modal — it lets the user explore their results first (see the comment in
+    // AuditClient.runAnalysis). First confirm the results rendered.
+    await expect(
+      page.getByRole('heading', { name: /your audit results/i })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Then attempt a second audit. With the free limit reached (count = 1),
+    // "New audit" routes through handleClear, which gates on isPaywalled and
+    // surfaces the unlock modal — the paywall's natural trigger point now.
+    await page.getByRole('button', { name: /new audit/i }).click();
     await expect(
       page.getByRole('heading', { name: /3 more audits/i }).first()
     ).toBeVisible({ timeout: 10_000 });
@@ -32,7 +41,7 @@ test.describe('audit funnel — happy path', () => {
     // would otherwise pick first.
     const emailField = page.getByPlaceholder(/you@company.com|your email/i).first();
     await emailField.fill('e2e@example.com');
-    await page.getByRole('button', { name: /unlock 3 more audits/i }).click();
+    await page.getByRole('button', { name: /^unlock audits$/i }).click();
     await expect(page.getByRole('heading', { name: /^unlocked$/i })).toBeVisible({ timeout: 10_000 });
     await page.getByRole('button', { name: /^continue$/i }).click();
 


### PR DESCRIPTION
## What

The `audit-flow` happy-path E2E spec has been failing on every nightly run for ~a week. **Root cause: a stale test, not a product bug.**

The spec asserted the unlock modal **auto-opens ~600ms after the first free audit**. The June 2026 results-view redesign deliberately removed that auto-open — see the comment in `AuditClient.runAnalysis` ("let the user explore their results first"). The paywall now surfaces when the user **attempts a second audit**. The spec also clicked a button labelled "Unlock 3 more audits", which was renamed to "Unlock audits".

## Fix

Update the spec to the current contract:
- After audit #1, assert the results render.
- Click "New audit" → `handleClear` gates on `isPaywalled` (`FREE_AUDIT_LIMIT = 1`) → unlock modal appears.
- Submit email via the renamed "Unlock audits" button.
- Post-unlock audits #2–4 and the final-cap (`UNLOCKED_AUDIT_LIMIT = 4`) assertions are unchanged.

No product code touched.

## Verification

Reproduced the failure locally, then confirmed the fix: full Playwright suite **3/3 green**.

## Notes

This test is not a required merge check, so it wasn't blocking anything — but it makes the nightly E2E signal trustworthy again.