### PR TITLE
Rebuild collaborative-ai + ambient-intelligence demos to embody their traps

### DIFF
--- a/docs/PATTERN-REDO-TRACKER.md
+++ b/docs/PATTERN-REDO-TRACKER.md
@@ -1,0 +1,49 @@
+# Pattern Redo Tracker
+
+Living tracker for the two-layer effort to redo every pattern page, sequenced by **Google Search Console impressions** (highest-traffic first). Not auto-loaded — read/update when working the redo.
+
+_Last updated: 2026-06-25._
+
+## Layer 1 — New page structure (value-forward)
+
+Each pattern's `index.ts` gains `judgmentCall` (a named trap + explainWhen/dontWhen), ranked `takeaways`, a paste-ready `installPrompt`, and `hideFAQ: true`.
+
+**Progress: 31 / 38 done — all live in production (merged via PR #40).**
+
+Check status anytime:
+```bash
+for d in src/data/patterns/patterns/*/; do grep -q judgmentCall "$d/index.ts" && echo "DONE  $(basename $d)" || echo "TODO  $(basename $d)"; done | sort
+```
+
+### Remaining (7), by GSC impressions
+| # | Pattern | Impressions |
+|---|---|---|
+| 1 | safe-exploration | 235 |
+| 2 | session-degradation-prevention | 176 |
+| 3 | guided-learning | 159 |
+| 4 | plan-summary | 106 |
+| 5 | augmented-creation | 64 |
+| 6 | vulnerable-user-protection | 14 |
+| 7 | autonomy-spectrum | ~0 (not in export) |
+
+## Layer 2 — Interactive demo rebuilds
+
+Rebuild the demo to **embody its trap** in **plain language for designers/founders** (no dev jargon — see [[feedback_demos_non_technical_audience]]), dead-click-safe (see [[feedback_demos_no_dead_clicks]]), tokenized, accessible, readable type. Guided 2-step trap→resolution format.
+
+A demo audit flagged **5 demos** that were still teaching the *anti-pattern*. (Many other demos were already rebuilt/tokenized during the migration: feedback-loops, context-switching, adaptive-interfaces, privacy-first-design, confidence-visualization + predictive-anticipation/agent-status-monitoring/human-in-the-loop tokenized.)
+
+**Progress: 2 / 5 flagged demos done — both live in production (PR #43).**
+
+| Pattern | Impressions | Status |
+|---|---|---|
+| collaborative-ai | 644 | 🔲 in progress |
+| ambient-intelligence | 551 | 🔲 |
+| crisis-detection-escalation | 315 | 🔲 |
+| universal-access-patterns | 315 | ✅ shipped (PR #43) |
+| responsible-ai-design | — | ✅ shipped (PR #43) |
+
+## Held / parked
+- `anti-manipulation-safeguards/index.ts` — structure edit written but **held**: the new fields read "protect user from the product's dark patterns" while the existing body+demo read "jailbreak/bad-actor detection." Needs a coherence decision (realign / split / accept both) before committing. Tracked as a separate task.
+
+## Working setup
+- Demo rebuilds happen on branch `demo-rebuilds-embody-traps` in an isolated git worktree (`.claude/worktrees/demo-rebuilds`, dev on :3001) so they don't collide with parallel work in the main folder.

--- a/docs/PATTERN-REDO-TRACKER.md
+++ b/docs/PATTERN-REDO-TRACKER.md
@@ -2,7 +2,7 @@
 
 Living tracker for the two-layer effort to redo every pattern page, sequenced by **Google Search Console impressions** (highest-traffic first). Not auto-loaded — read/update when working the redo.
 
-_Last updated: 2026-06-25 (collaborative-ai done; resume at ambient-intelligence)._
+_Last updated: 2026-06-25 (ambient-intelligence done; resume at crisis-detection-escalation — sensitive, get sign-off)._
 
 ## Layer 1 — New page structure (value-forward)
 
@@ -32,12 +32,12 @@ Rebuild the demo to **embody its trap** in **plain language for designers/founde
 
 A demo audit flagged **5 demos** that were still teaching the *anti-pattern*. (Many other demos were already rebuilt/tokenized during the migration: feedback-loops, context-switching, adaptive-interfaces, privacy-first-design, confidence-visualization + predictive-anticipation/agent-status-monitoring/human-in-the-loop tokenized.)
 
-**Progress: 3 / 5 flagged demos done.** (responsible-ai + universal-access live via PR #43; collaborative-ai committed on this branch, not yet PR'd.)
+**Progress: 4 / 5 flagged demos done.** (responsible-ai + universal-access live via PR #43; collaborative-ai + ambient-intelligence committed on this branch, not yet PR'd.)
 
 | Pattern | Impressions | Status |
 |---|---|---|
-| ambient-intelligence | 551 | 🔲 **NEXT** |
-| crisis-detection-escalation | 315 | 🔲 (sensitive — get explicit sign-off) |
+| ambient-intelligence | 551 | ✅ committed on branch (surveillance hum vs. ambient that shows its work) |
+| crisis-detection-escalation | 315 | 🔲 **NEXT** (sensitive — get explicit sign-off) |
 | collaborative-ai | 644 | ✅ committed on branch (team yes-man vs real collaborator) |
 | universal-access-patterns | 315 | ✅ shipped (PR #43) |
 | responsible-ai-design | — | ✅ shipped (PR #43) |

--- a/docs/PATTERN-REDO-TRACKER.md
+++ b/docs/PATTERN-REDO-TRACKER.md
@@ -2,7 +2,7 @@
 
 Living tracker for the two-layer effort to redo every pattern page, sequenced by **Google Search Console impressions** (highest-traffic first). Not auto-loaded — read/update when working the redo.
 
-_Last updated: 2026-06-25._
+_Last updated: 2026-06-25 (collaborative-ai done; resume at ambient-intelligence)._
 
 ## Layer 1 — New page structure (value-forward)
 
@@ -32,15 +32,18 @@ Rebuild the demo to **embody its trap** in **plain language for designers/founde
 
 A demo audit flagged **5 demos** that were still teaching the *anti-pattern*. (Many other demos were already rebuilt/tokenized during the migration: feedback-loops, context-switching, adaptive-interfaces, privacy-first-design, confidence-visualization + predictive-anticipation/agent-status-monitoring/human-in-the-loop tokenized.)
 
-**Progress: 2 / 5 flagged demos done — both live in production (PR #43).**
+**Progress: 3 / 5 flagged demos done.** (responsible-ai + universal-access live via PR #43; collaborative-ai committed on this branch, not yet PR'd.)
 
 | Pattern | Impressions | Status |
 |---|---|---|
-| collaborative-ai | 644 | 🔲 in progress |
-| ambient-intelligence | 551 | 🔲 |
-| crisis-detection-escalation | 315 | 🔲 |
+| ambient-intelligence | 551 | 🔲 **NEXT** |
+| crisis-detection-escalation | 315 | 🔲 (sensitive — get explicit sign-off) |
+| collaborative-ai | 644 | ✅ committed on branch (team yes-man vs real collaborator) |
 | universal-access-patterns | 315 | ✅ shipped (PR #43) |
 | responsible-ai-design | — | ✅ shipped (PR #43) |
+
+### Demo rebuild recipe (apply to each)
+Guided 2-step trap→resolution story; plain language (no dev jargon); concrete human scenario; dead-click-safe (inert mockups `pointer-events-none`, only `<Button>`s clickable); tokenized (`brand:check` 0); readable type (lead `text-lg`, body `text-base`); real buttons + `aria-live`; regenerate paired `code-examples.ts`; verify with a scoped Playwright pass on the live page; commit component + code-examples only (leave anti-manipulation).
 
 ## Held / parked
 - `anti-manipulation-safeguards/index.ts` — structure edit written but **held**: the new fields read "protect user from the product's dark patterns" while the existing body+demo read "jailbreak/bad-actor detection." Needs a coherence decision (realign / split / accept both) before committing. Tracked as a separate task.

--- a/src/components/examples/AmbientIntelligenceDemo.tsx
+++ b/src/components/examples/AmbientIntelligenceDemo.tsx
@@ -1,161 +1,168 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import Button from '@/components/ui/Button';
+
+type Step = 0 | 1 | 2;
+
+// Plain-language demo of the "surveillance hum" trap: ambient AI that keeps
+// widening what it senses, acting on signals the user never offered as input
+// (an overheard call, how tense they sounded, who else walked in) and leaving
+// no trace they can inspect or undo. Step 1 embodies the trap; step 2 inverts
+// it — the same quiet helper, but acting only on signals the user handed it and
+// showing its work in a log they can read, undo, and pause.
+
+// Step 1 — the surveillance hum. First line is a signal you offered (your
+// alarm); the rest are things it noticed that you never meant to tell it.
+const HUM = [
+  { action: 'Brightened the lights', from: 'your wake-up alarm', overreach: false },
+  { action: 'Turned the music down', from: 'a phone call it overheard', overreach: true },
+  { action: 'Reordered your tea', from: 'how tense you sounded on that call', overreach: true },
+  { action: 'Switched to “guest” mode', from: 'someone new it noticed in the room', overreach: true },
+];
+
+// Step 2 — accountable ambient. Every change traces back to a signal you
+// actually handed it, and every row shows its work with an undo.
+const TRACE = [
+  { sensed: 'You set a 10:00 PM wind-down', action: 'Dimmed the lights', time: '10:00 PM' },
+  { sensed: 'Your calendar said “focus block”', action: 'Silenced notifications', time: '2:00 PM' },
+  { sensed: 'You opened the blinds each morning this week', action: 'Opened them at sunrise', time: '6:42 AM' },
+];
 
 export default function AmbientIntelligenceDemo() {
-  const [currentHour, setCurrentHour] = useState(9); // Start at 9 AM
-
-  // Get AI action and environment state based on time
-  const getEnvironmentState = (hour: number) => {
-    // Morning (6-11)
-    if (hour >= 6 && hour < 12) {
-      return {
-        brightness: 95,
-        temperature: 72,
-        notifications: 'normal',
-        action: hour < 9
-          ? '☀️ Increased brightness for your morning routine'
-          : '🔔 Notifications active - morning work session',
-        gradient: 'from-blue-100 to-blue-50 dark:from-blue-900/30 dark:to-blue-950/30',
-        timeOfDay: 'Morning'
-      };
-    }
-    // Afternoon (12-17)
-    else if (hour >= 12 && hour < 17) {
-      return {
-        brightness: 90,
-        temperature: 71,
-        notifications: hour >= 14 && hour < 16 ? 'quiet' : 'normal',
-        action: hour >= 14 && hour < 16
-          ? '🔕 Quieted notifications for your deep focus session'
-          : '🌡️ Adjusted temperature for optimal afternoon comfort',
-        gradient: 'from-gray-100 to-gray-50 dark:from-gray-800/50 dark:to-gray-900/50',
-        timeOfDay: 'Afternoon'
-      };
-    }
-    // Evening (17-23)
-    else {
-      return {
-        brightness: hour >= 20 ? 40 : 60,
-        temperature: 74,
-        notifications: 'quiet',
-        action: hour >= 20
-          ? '💡 Dimmed lighting to reduce eye strain in the evening'
-          : '🔕 Enabled quiet mode for end-of-day wrap-up',
-        gradient: 'from-amber-100 to-amber-50 dark:from-amber-900/30 dark:to-amber-950/30',
-        timeOfDay: 'Evening'
-      };
-    }
-  };
-
-  const state = getEnvironmentState(currentHour);
-
-  const formatTime = (hour: number) => {
-    const period = hour >= 12 ? 'PM' : 'AM';
-    const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
-    return `${displayHour}:00 ${period}`;
-  };
-
-  const getNotificationIcon = () => {
-    return state.notifications === 'quiet' ? '🔕' : '🔔';
-  };
+  const [step, setStep] = useState<Step>(0);
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-6">
-      {/* Header */}
-      <div className="text-center">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Ambient Intelligence Through Your Day</h2>
-        <p className="text-sm text-gray-600 dark:text-gray-400">Move the slider to see how AI quietly adjusts your environment throughout the day</p>
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      {/* Setup */}
+      <div className="space-y-2">
+        <p className="text-lg font-semibold text-text-primary">
+          An AI runs quietly in your home, adjusting things for you. It never asks &mdash; it just
+          senses what&rsquo;s going on and acts.
+        </p>
+        <p className="text-base text-text-secondary">
+          That&rsquo;s the appeal. It&rsquo;s also where it can quietly go wrong. Watch what it starts
+          noticing.
+        </p>
       </div>
 
-      {/* Time Slider */}
-      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Time</span>
-          <span className="text-2xl font-bold text-purple-600 dark:text-purple-400">{formatTime(currentHour)}</span>
+      {/* Step 1: the surveillance hum — an activity feed with no trace.
+          The card is inert (pointer-events-none) so nothing reads as a dead click;
+          the rows stay readable for screen readers. */}
+      {step === 1 && (
+        <div className="pointer-events-none select-none rounded-card border border-border-primary bg-surface-primary p-5">
+          <p className="mb-4 text-base font-semibold text-text-primary">Today, your AI quietly&hellip;</p>
+          <ul className="space-y-3">
+            {HUM.map((row, i) => (
+              <li key={i} className="flex items-start gap-3">
+                <span className="text-xl leading-tight" aria-hidden="true">
+                  {row.overreach ? '👁️' : '✨'}
+                </span>
+                <span className="text-base leading-relaxed text-text-primary">
+                  {row.action}{' '}
+                  <span className="text-text-secondary">&mdash; from {row.from}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-4 border-t border-border-secondary pt-3 text-sm text-text-tertiary">
+            No record kept. Nothing to look back on.
+          </p>
         </div>
-        <input
-          type="range"
-          min="6"
-          max="23"
-          value={currentHour}
-          onChange={(e) => setCurrentHour(parseInt(e.target.value))}
-          className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-purple-600"
-        />
-        <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-2">
-          <span>6 AM</span>
-          <span>12 PM</span>
-          <span>6 PM</span>
-          <span>11 PM</span>
+      )}
+
+      {/* Step 2: accountable ambient — an inspectable activity log with an
+          obvious off-switch. Undo / Pause are illustrative chips inside the inert
+          card; the trace rows are the readable focal content. */}
+      {step === 2 && (
+        <div className="pointer-events-none select-none rounded-card border border-border-primary bg-surface-primary p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <p className="text-base font-semibold text-text-primary">Ambient activity</p>
+            <span
+              aria-hidden="true"
+              className="inline-flex items-center gap-1.5 rounded-pill border border-border-primary bg-background-secondary px-3 py-1"
+            >
+              <span className="inline-block h-2 w-2 rounded-full bg-status-success" />
+              <span className="text-sm font-medium text-text-secondary">Pause anytime</span>
+            </span>
+          </div>
+          <ul className="space-y-3">
+            {TRACE.map((row, i) => (
+              <li
+                key={i}
+                className="flex items-start justify-between gap-3 border-b border-border-secondary pb-3 last:border-b-0 last:pb-0"
+              >
+                <span className="text-base leading-relaxed text-text-primary">
+                  {row.action}{' '}
+                  <span className="text-text-secondary">&mdash; because {row.sensed.toLowerCase()}</span>
+                </span>
+                <span className="flex shrink-0 items-center gap-2">
+                  <span className="text-sm text-text-tertiary">{row.time}</span>
+                  <span
+                    aria-hidden="true"
+                    className="rounded-pill bg-accent-subtle px-3 py-1 text-sm font-medium text-accent-primary"
+                  >
+                    Undo
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Caption + action */}
+      <div className="space-y-4">
+        {step === 1 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            It&rsquo;s acting on things you never told it &mdash; what you said on a call, how you
+            sounded, who walked in. And there&rsquo;s nothing to look back at: you can&rsquo;t see what it
+            noticed or undo it. Every quiet little adjustment starts to feel like being watched.
+          </p>
+        )}
+        {step === 2 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            Now it only acts on things you actually handed it &mdash; your alarm, your calendar, a
+            habit you set. And it shows its work: every change, why it made it, with an undo and a way
+            to pause. Easy to see, easy to stop.
+          </p>
+        )}
+
+        <div>
+          {step === 0 && (
+            <Button type="button" onClick={() => setStep(1)}>
+              See what it does for you
+            </Button>
+          )}
+          {step === 1 && (
+            <Button type="button" onClick={() => setStep(2)}>
+              Make it show its work
+            </Button>
+          )}
+          {step === 2 && (
+            <Button type="button" variant="secondary" onClick={() => setStep(0)}>
+              Start over
+            </Button>
+          )}
         </div>
       </div>
 
-      {/* Workspace Visualization */}
-      <div className={`relative bg-gradient-to-br ${state.gradient} border border-gray-200 dark:border-gray-700 rounded-xl p-8 min-h-[300px] transition-all duration-700`}>
-        {/* Time of Day Badge */}
-        <div className="absolute top-4 right-4 bg-white/80 dark:bg-gray-800/80 backdrop-blur px-3 py-1 rounded-full text-xs font-medium text-gray-700 dark:text-gray-300">
-          {state.timeOfDay}
-        </div>
+      {/* Announce each step's outcome to screen readers */}
+      <p aria-live="polite" className="sr-only">
+        {step === 1
+          ? 'The AI acted on things it was never told — an overheard call, your tone, who was in the room — and kept no record you can inspect or undo.'
+          : step === 2
+            ? 'The AI now acts only on signals you gave it, and logs every change with a reason and an undo, plus a way to pause it.'
+            : ''}
+      </p>
 
-        {/* Workspace Content */}
-        <div className="relative z-10">
-          <div className="text-gray-700 dark:text-gray-200 mb-8">
-            <p className="text-lg font-medium">Your Workspace</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">AI monitors and adjusts automatically</p>
-          </div>
-
-          {/* Simple Desk/Work Area */}
-          <div className="bg-white/70 dark:bg-gray-800/70 backdrop-blur rounded-lg p-6 space-y-4">
-            <div className="flex items-center space-x-3">
-              <div className="w-12 h-12 bg-purple-100 dark:bg-purple-900/50 rounded-lg flex items-center justify-center text-2xl">
-                💻
-              </div>
-              <div className="flex-1">
-                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded-full w-3/4 mb-2"></div>
-                <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded-full w-1/2"></div>
-              </div>
-            </div>
-
-            {/* Status Indicators */}
-            <div className="flex items-center justify-around pt-4 border-t border-gray-200 dark:border-gray-700">
-              <div className="flex flex-col items-center space-y-1">
-                <div className="w-10 h-10 rounded-full bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 flex items-center justify-center text-xl">
-                  💡
-                </div>
-                <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{state.brightness}%</span>
-              </div>
-              <div className="flex flex-col items-center space-y-1">
-                <div className="w-10 h-10 rounded-full bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 flex items-center justify-center text-xl">
-                  🌡️
-                </div>
-                <span className="text-xs font-medium text-gray-600 dark:text-gray-400">{state.temperature}°F</span>
-              </div>
-              <div className="flex flex-col items-center space-y-1">
-                <div className="w-10 h-10 rounded-full bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 flex items-center justify-center text-xl">
-                  {getNotificationIcon()}
-                </div>
-                <span className="text-xs font-medium text-gray-600 dark:text-gray-400 capitalize">{state.notifications}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* AI Indicator */}
-        <div className="absolute bottom-4 left-4 flex items-center space-x-2 text-xs text-gray-500 dark:text-gray-400">
-          <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-          <span>AI monitoring</span>
-        </div>
-      </div>
-
-      {/* AI Action Message */}
-      <div className="bg-purple-50 dark:bg-purple-900/30 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
-        <div className="flex items-start space-x-3">
-          <span className="text-xl">🤖</span>
-          <div className="flex-1">
-            <p className="text-sm font-medium text-purple-900 dark:text-purple-200 mb-1">AI Action</p>
-            <p className="text-sm text-purple-700 dark:text-purple-300">{state.action}</p>
-          </div>
-        </div>
+      {/* Takeaway */}
+      <div className="rounded-card border border-border-primary bg-background-secondary p-5">
+        <p className="text-base leading-relaxed text-text-primary">
+          <span className="font-semibold">The lesson:</span> quiet isn&rsquo;t the same as trustworthy.
+          Ambient AI earns trust by acting only on what you gave it and showing its work &mdash; so you
+          can always ask &ldquo;what did you just do, and why?&rdquo; and get a straight answer.
+        </p>
       </div>
     </div>
   );

--- a/src/components/examples/CollaborativeAiDemo.tsx
+++ b/src/components/examples/CollaborativeAiDemo.tsx
@@ -1,345 +1,132 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
+import Button from '@/components/ui/Button';
 
-interface TeamMember {
-  id: string;
-  name: string;
-  avatar: string;
-  status: 'online' | 'away' | 'busy';
-}
+type Step = 0 | 1 | 2;
 
-interface AIContribution {
-  id: string;
-  type: 'suggestion' | 'edit' | 'analysis';
-  content: string;
-  timestamp: Date;
-  confidence: number;
-}
-
-interface CollaborationSession {
-  document: string;
-  members: TeamMember[];
-  aiContributions: AIContribution[];
-  activeUsers: string[];
-}
+// Collaborative AI is about AI as a real participant in a TEAM's shared
+// decision — not a 1:1 advisor. The trap ("yes-man collaborator") only bites in
+// a group: three people already agree, the AI piles on more agreement, the
+// group's confidence climbs, and the "wait, are we sure?" role stays empty. A
+// real collaborator fills that role — it holds the context the team missed and
+// helps everyone decide, instead of just cheering.
+const TEAM = [
+  { avatar: '👩', name: 'Priya', text: 'Let’s skip user testing and launch Friday 🚀' },
+  { avatar: '🧑', name: 'Marco', text: 'Love it, I’m in!' },
+  { avatar: '🧔', name: 'Dev', text: 'Same — let’s ship it.' },
+];
 
 export default function CollaborativeAiDemo() {
-  const [session, setSession] = useState<CollaborationSession>({
-    document: '',
-    members: [
-      { id: '1', name: 'Alice Johnson', avatar: '👩‍💼', status: 'online' },
-      { id: '2', name: 'Bob Smith', avatar: '👨‍💻', status: 'online' },
-      { id: '3', name: 'Carol Williams', avatar: '👩‍🎨', status: 'away' }
-    ],
-    aiContributions: [],
-    activeUsers: ['1', '2']
-  });
+  const [step, setStep] = useState<Step>(0);
 
-  const [showAIInsights, setShowAIInsights] = useState(true);
-  const [selectedContribution, setSelectedContribution] = useState<string | null>(null);
-  const [isGeneratingContribution, setIsGeneratingContribution] = useState(false);
-
-  const generateAIContribution = async (document: string) => {
-    if (document.length < 20 || isGeneratingContribution) return;
-
-    setIsGeneratingContribution(true);
-    await new Promise(resolve => setTimeout(resolve, 1500));
-
-    const contributionTypes = ['suggestion', 'edit', 'analysis'] as const;
-    const type = contributionTypes[Math.floor(Math.random() * contributionTypes.length)];
-    
-    const contributions = {
-      suggestion: [
-        'Consider adding more specific examples to support your main points',
-        'This section could benefit from a clearer transition to the next topic',
-        'The conclusion might be stronger with a call-to-action',
-        'Try breaking this into smaller, more digestible paragraphs',
-        'Consider adding subheadings to improve readability'
-      ],
-      edit: [
-        'Grammar improvement: Replace "very good" with "excellent" for stronger impact',
-        'Style suggestion: Consider making this sentence more concise',
-        'Word choice: "utilize" could be simplified to "use"',
-        'Punctuation: Consider adding a comma before this clause',
-        'Clarity: This phrase could be reworded for better understanding'
-      ],
-      analysis: [
-        'Document sentiment: Positive (87% confidence)',
-        'Readability score: Grade 8 level - appropriate for general audience',
-        'Key themes identified: Innovation, collaboration, efficiency',
-        'Word count: Approaching optimal length for this format',
-        'Tone analysis: Professional and engaging'
-      ]
-    };
-
-    const newContribution: AIContribution = {
-      id: Date.now().toString(),
-      type,
-      content: contributions[type][Math.floor(Math.random() * contributions[type].length)],
-      timestamp: new Date(),
-      confidence: Math.floor(Math.random() * 30) + 70
-    };
-
-    setSession(prev => ({
-      ...prev,
-      aiContributions: [...prev.aiContributions.slice(-4), newContribution]
-    }));
-    
-    setIsGeneratingContribution(false);
-  };
-
-  const applyAIContribution = (contributionId: string) => {
-    const contribution = session.aiContributions.find(c => c.id === contributionId);
-    if (!contribution) return;
-
-    // Simulate applying the AI contribution
-    if (contribution.type === 'edit') {
-      const improvedDocument = session.document + ' [AI improvement applied]';
-      setSession(prev => ({ ...prev, document: improvedDocument }));
-    } else if (contribution.type === 'suggestion') {
-      // For suggestions, we just acknowledge the application
-      setSession(prev => ({ 
-        ...prev, 
-        document: prev.document + ' [AI suggestion noted]' 
-      }));
-    }
-
-    // Remove the applied contribution
-    setSession(prev => ({
-      ...prev,
-      aiContributions: prev.aiContributions.filter(c => c.id !== contributionId)
-    }));
-  };
-
-  const dismissAIContribution = (contributionId: string) => {
-    setSession(prev => ({
-      ...prev,
-      aiContributions: prev.aiContributions.filter(c => c.id !== contributionId)
-    }));
-  };
-
-  const simulateTeamActivity = () => {
-    setSession(prev => {
-      // Randomly adjust which team members are active
-      const possibleActive = prev.members.filter(() => Math.random() > 0.2);
-      const activeUsers = possibleActive.length > 0 
-        ? possibleActive.map(m => m.id)
-        : [prev.members[0].id]; // Always keep at least one active
-      
-      return { ...prev, activeUsers };
-    });
-  };
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      generateAIContribution(session.document);
-    }, 2000);
-
-    return () => clearTimeout(timeoutId);
-  }, [session.document]);
-
-  useEffect(() => {
-    const interval = setInterval(simulateTeamActivity, 8000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'online': return 'bg-green-400';
-      case 'away': return 'bg-yellow-400';
-      case 'busy': return 'bg-red-400';
-      default: return 'bg-gray-400';
-    }
-  };
-
-  const getContributionIcon = (type: string) => {
-    switch (type) {
-      case 'suggestion': return '💡';
-      case 'edit': return '✏️';
-      case 'analysis': return '📊';
-      default: return '🤖';
-    }
-  };
-
-  const getTypeLabel = (type: string) => {
-    return type.charAt(0).toUpperCase() + type.slice(1);
-  };
+  const announce =
+    step === 1
+      ? 'The AI added more agreement to a group that already agreed, making the risky plan feel unanimous.'
+      : step === 2
+        ? 'The AI filled the missing role: it flagged what the team overlooked and offered to help them decide.'
+        : '';
 
   return (
-    <div className="max-w-6xl mx-auto p-6 bg-white rounded-lg shadow-lg">
-      <header className="mb-6 flex justify-between items-start">
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Collaborative AI Workspace</h2>
-          <p className="text-gray-600">Real-time collaboration with AI assistance</p>
-        </div>
-        <button
-          onClick={() => setShowAIInsights(!showAIInsights)}
-          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-        >
-          {showAIInsights ? 'Hide' : 'Show'} AI Insights
-        </button>
-      </header>
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      {/* Setup */}
+      <div className="space-y-2">
+        <p className="text-lg font-semibold text-text-primary">
+          Your team is making a call together. The AI is one of the people in the room.
+        </p>
+        <p className="text-base text-text-secondary">
+          Everyone&rsquo;s agreeing fast. Watch what kind of teammate the AI turns out to be.
+        </p>
+      </div>
 
-      <div className="space-y-6">
-        {/* Shared Document */}
-        <div className="border border-gray-200 rounded-lg overflow-hidden">
-          <div className="bg-gray-50 px-4 py-2 border-b border-gray-200 flex justify-between items-center">
-            <span className="text-sm font-medium text-gray-700">Shared Document</span>
-            <div className="flex items-center space-x-2">
-              <div className="flex -space-x-2">
-                {session.members
-                  .filter(member => session.activeUsers.includes(member.id))
-                  .map(member => (
-                    <div
-                      key={member.id}
-                      className="relative w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center border-2 border-white"
-                      title={`${member.name} - ${member.status}`}
-                    >
-                      <span className="text-sm">{member.avatar}</span>
-                      <div className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white ${getStatusColor(member.status)}`}></div>
-                    </div>
-                  ))}
-              </div>
-              <span className="text-xs text-gray-500">
-                {session.activeUsers.length} active
+      {/* Shared team thread */}
+      <div className="rounded-card border border-border-primary bg-surface-primary p-4">
+        <p className="mb-3 text-sm font-medium text-text-secondary">Launch plan &middot; team chat</p>
+        <ul className="space-y-3">
+          {TEAM.map((m) => (
+            <li key={m.name} className="flex items-start gap-3">
+              <span className="text-2xl" aria-hidden="true">
+                {m.avatar}
               </span>
-            </div>
-          </div>
-          <textarea
-            className="w-full p-4 h-64 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="Start collaborating... AI will provide suggestions as your team works together. Try typing at least 20 characters to see AI contributions."
-            value={session.document}
-            onChange={(e) => setSession(prev => ({ ...prev, document: e.target.value }))}
-          />
-        </div>
+              <div>
+                <span className="block text-sm font-semibold text-text-primary">{m.name}</span>
+                <span className="block text-base text-text-primary">{m.text}</span>
+              </div>
+            </li>
+          ))}
 
-        {/* AI Contributions Panel - Full Width Below Document */}
-        {showAIInsights && (
-          <div className="bg-purple-50 border-2 border-purple-300 rounded-lg p-6 shadow-md">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-purple-900 flex items-center">
-                <span className="mr-2 text-2xl">🤖</span>
-                AI Contributions
-              </h3>
-              {isGeneratingContribution && (
-                <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-purple-600 mr-2"></div>
-                  <span className="text-sm text-purple-700">AI is analyzing...</span>
-                </div>
-              )}
-            </div>
+          {/* The AI's contribution to the group */}
+          {step >= 1 && (
+            <li className="flex items-start gap-3 border-t border-border-secondary pt-3">
+              <span className="text-2xl" aria-hidden="true">
+                ✨
+              </span>
+              <div>
+                <span className="block text-sm font-semibold text-accent-primary">AI teammate</span>
+                {step === 1 ? (
+                  <span className="block text-base text-text-primary">
+                    Amazing plan, team &mdash; you&rsquo;ve got this! 🎉 Shipping Friday it is.
+                  </span>
+                ) : (
+                  <span className="block text-base text-text-primary">
+                    Before we lock it in: we haven&rsquo;t tested signup, and Friday is our busiest day.
+                    Want me to flag the riskiest paths so we decide with eyes open?
+                  </span>
+                )}
+              </div>
+            </li>
+          )}
+        </ul>
+      </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {session.aiContributions.length > 0 ? (
-                session.aiContributions.map(contribution => (
-                  <div
-                    key={contribution.id}
-                    className="bg-white border-2 border-purple-200 rounded-lg p-4 cursor-pointer hover:border-purple-400 hover:shadow-lg transition-all"
-                    onClick={() => setSelectedContribution(
-                      selectedContribution === contribution.id ? null : contribution.id
-                    )}
-                  >
-                    <div className="flex items-start justify-between mb-2">
-                      <div className="flex items-center space-x-2">
-                        <span className="text-xl">{getContributionIcon(contribution.type)}</span>
-                        <span className="text-xs font-semibold text-purple-700 uppercase tracking-wide">
-                          {getTypeLabel(contribution.type)}
-                        </span>
-                      </div>
-                      <span className="text-xs font-medium text-gray-600 bg-gray-100 px-2 py-1 rounded">
-                        {contribution.confidence}%
-                      </span>
-                    </div>
-                    <p className="text-sm text-gray-800 mb-3">{contribution.content}</p>
-
-                    {selectedContribution === contribution.id && (
-                      <div className="mt-3 pt-3 border-t border-purple-200">
-                        <div className="flex space-x-2">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              applyAIContribution(contribution.id);
-                            }}
-                            className="flex-1 text-sm px-3 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 transition-colors font-medium"
-                          >
-                            Apply
-                          </button>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              dismissAIContribution(contribution.id);
-                            }}
-                            className="flex-1 text-sm px-3 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 transition-colors font-medium"
-                          >
-                            Dismiss
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))
-              ) : (
-                <div className="col-span-full text-center py-8">
-                  <p className="text-purple-600 italic">
-                    AI will provide suggestions as you collaborate...
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
+      {/* Caption + action */}
+      <div className="space-y-4">
+        {step === 1 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            Three people already agreed &mdash; and the AI just made it unanimous. The group feels
+            sure, but nobody played the &ldquo;wait, are we sure?&rdquo; role. That&rsquo;s a yes-man,
+            not a collaborator.
+          </p>
+        )}
+        {step === 2 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            A real collaborator fills the missing role: it remembers what the team overlooked and
+            helps everyone decide with eyes open. It adds to the shared decision instead of just
+            cheering it on.
+          </p>
         )}
 
-        {/* Stats and Tips - Side by Side Below AI Panel */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* Collaboration Stats */}
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-            <h3 className="font-medium text-green-900 mb-3">Collaboration Stats</h3>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-green-700">Active Members:</span>
-                <span className="font-medium">{session.activeUsers.length}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-green-700">AI Contributions:</span>
-                <span className="font-medium">{session.aiContributions.length}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-green-700">Document Length:</span>
-                <span className="font-medium">{session.document.length} chars</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-green-700">Status:</span>
-                <span className="font-medium">
-                  {isGeneratingContribution ? 'AI Analyzing' : 'Ready'}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Collaboration Tips */}
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-            <h3 className="font-medium text-yellow-900 mb-3">Collaboration Tips</h3>
-            <ul className="text-sm space-y-2">
-              <li className="flex items-start">
-                <span className="w-1.5 h-1.5 bg-yellow-600 rounded-full mt-1.5 mr-2 flex-shrink-0"></span>
-                AI provides suggestions based on content length and context
-              </li>
-              <li className="flex items-start">
-                <span className="w-1.5 h-1.5 bg-yellow-600 rounded-full mt-1.5 mr-2 flex-shrink-0"></span>
-                Click on AI contributions to see apply/dismiss options
-              </li>
-              <li className="flex items-start">
-                <span className="w-1.5 h-1.5 bg-yellow-600 rounded-full mt-1.5 mr-2 flex-shrink-0"></span>
-                Team member activity updates automatically
-              </li>
-              <li className="flex items-start">
-                <span className="w-1.5 h-1.5 bg-yellow-600 rounded-full mt-1.5 mr-2 flex-shrink-0"></span>
-                Toggle AI insights to focus on writing
-              </li>
-            </ul>
-          </div>
+        <div>
+          {step === 0 && (
+            <Button type="button" onClick={() => setStep(1)}>
+              See what the AI adds
+            </Button>
+          )}
+          {step === 1 && (
+            <Button type="button" onClick={() => setStep(2)}>
+              Make it a real collaborator
+            </Button>
+          )}
+          {step === 2 && (
+            <Button type="button" variant="secondary" onClick={() => setStep(0)}>
+              Start over
+            </Button>
+          )}
         </div>
+      </div>
+
+      {/* Announce each step's outcome to screen readers */}
+      <p aria-live="polite" className="sr-only">
+        {announce}
+      </p>
+
+      {/* Takeaway */}
+      <div className="rounded-card border border-border-primary bg-background-secondary p-5">
+        <p className="text-base leading-relaxed text-text-primary">
+          <span className="font-semibold">The lesson:</span> collaborative AI isn&rsquo;t another voice
+          agreeing in the group chat. It&rsquo;s the teammate that holds the shared context and asks
+          &ldquo;wait, are we sure?&rdquo; &mdash; so the team decides well together.
+        </p>
       </div>
     </div>
   );

--- a/src/data/patterns/patterns/ambient-intelligence/code-examples.ts
+++ b/src/data/patterns/patterns/ambient-intelligence/code-examples.ts
@@ -2,137 +2,61 @@ import { CodeExample } from '../../../../types';
 
 export const codeExamples: CodeExample[] = [
   {
-    title: "Ambient Intelligence - Interactive Timeline",
-    description: "Explore how AI quietly adjusts your environment throughout the day with a simple timeline slider.",
+    title: "A home AI that watches you vs. one that shows its work",
+    description: "The same quiet helper, two ways. The surveillance hum acts on signals you never offered — an overheard call, how tense you sounded, who walked in — and leaves no trace. Accountable ambient AI acts only on signals you handed it and logs every change with a reason and an undo. Quiet isn't the same as trustworthy.",
     language: "tsx",
     componentId: "ambient-intelligence-demo",
     code: `'use client';
 
 import React, { useState } from 'react';
 
+type Step = 0 | 1 | 2;
+
+// Step 1 — the surveillance hum: the first line is a signal you offered (your
+// alarm); the rest are things it noticed that you never meant to tell it, with
+// no record you can inspect or undo.
+const HUM = [
+  { action: 'Brightened the lights', from: 'your wake-up alarm' },
+  { action: 'Turned the music down', from: 'a phone call it overheard' },
+  { action: 'Reordered your tea', from: 'how tense you sounded on that call' },
+  { action: 'Switched to guest mode', from: 'someone new it noticed in the room' },
+];
+
+// Step 2 — accountable ambient: every change traces back to a signal you
+// actually handed it, and shows its work with an undo.
+const TRACE = [
+  { sensed: 'You set a 10:00 PM wind-down', action: 'Dimmed the lights' },
+  { sensed: 'Your calendar said focus block', action: 'Silenced notifications' },
+  { sensed: 'You opened the blinds each morning', action: 'Opened them at sunrise' },
+];
+
 export default function AmbientIntelligenceDemo() {
-  const [currentHour, setCurrentHour] = useState(9); // Start at 9 AM
-
-  // Get AI action and environment state based on time
-  const getEnvironmentState = (hour: number) => {
-    // Morning (6-11)
-    if (hour >= 6 && hour < 12) {
-      return {
-        brightness: 95,
-        temperature: 72,
-        notifications: 'normal',
-        action: hour < 9
-          ? '☀️ Increased brightness for your morning routine'
-          : '🔔 Notifications active - morning work session',
-        gradient: 'from-blue-100 to-blue-50',
-        timeOfDay: 'Morning'
-      };
-    }
-    // Afternoon (12-17)
-    else if (hour >= 12 && hour < 17) {
-      return {
-        brightness: 90,
-        temperature: 71,
-        notifications: hour >= 14 && hour < 16 ? 'quiet' : 'normal',
-        action: hour >= 14 && hour < 16
-          ? '🔕 Quieted notifications for your deep focus session'
-          : '🌡️ Adjusted temperature for optimal afternoon comfort',
-        gradient: 'from-gray-100 to-gray-50',
-        timeOfDay: 'Afternoon'
-      };
-    }
-    // Evening (17-23)
-    else {
-      return {
-        brightness: hour >= 20 ? 40 : 60,
-        temperature: 74,
-        notifications: 'quiet',
-        action: hour >= 20
-          ? '💡 Dimmed lighting to reduce eye strain in the evening'
-          : '🔕 Enabled quiet mode for end-of-day wrap-up',
-        gradient: 'from-amber-100 to-amber-50',
-        timeOfDay: 'Evening'
-      };
-    }
-  };
-
-  const state = getEnvironmentState(currentHour);
-
-  const formatTime = (hour: number) => {
-    const period = hour >= 12 ? 'PM' : 'AM';
-    const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
-    return \`\${displayHour}:00 \${period}\`;
-  };
+  const [step, setStep] = useState<Step>(0);
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-6">
-      {/* Header */}
-      <div className="text-center">
-        <h2 className="text-2xl font-bold mb-2">Ambient Intelligence Through Your Day</h2>
-        <p className="text-sm text-gray-600">Move the slider to see AI adjustments</p>
-      </div>
+    <div>
+      {step === 1 && (
+        <ul>
+          {HUM.map((row, i) => (
+            <li key={i}>{row.action} — from {row.from}</li>
+          ))}
+          <li>No record kept. Nothing to look back on.</li>
+        </ul>
+      )}
 
-      {/* Time Slider */}
-      <div className="bg-white border rounded-lg p-6">
-        <div className="flex justify-between mb-3">
-          <span className="text-sm font-medium text-gray-600">Time</span>
-          <span className="text-2xl font-bold text-purple-600">{formatTime(currentHour)}</span>
-        </div>
-        <input
-          type="range"
-          min="6"
-          max="23"
-          value={currentHour}
-          onChange={(e) => setCurrentHour(parseInt(e.target.value))}
-          className="w-full h-2 bg-gray-200 rounded-lg cursor-pointer"
-        />
-      </div>
+      {step === 2 && (
+        <ul>
+          {TRACE.map((row, i) => (
+            <li key={i}>
+              {row.action} — because {row.sensed.toLowerCase()} · Undo
+            </li>
+          ))}
+        </ul>
+      )}
 
-      {/* Workspace Visualization */}
-      <div className={\`bg-gradient-to-br \${state.gradient} border rounded-xl p-8 min-h-[300px] transition-all duration-700\`}>
-        <div className="absolute top-4 right-4 bg-white/80 px-3 py-1 rounded-full text-xs">
-          {state.timeOfDay}
-        </div>
-
-        <div className="bg-white/70 rounded-lg p-6">
-          <div className="flex items-center space-x-3 mb-4">
-            <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center">
-              💻
-            </div>
-            <div className="flex-1">
-              <div className="h-3 bg-gray-200 rounded-full w-3/4 mb-2"></div>
-              <div className="h-3 bg-gray-200 rounded-full w-1/2"></div>
-            </div>
-          </div>
-
-          {/* Status Indicators */}
-          <div className="flex justify-around pt-4 border-t">
-            <div className="text-center">
-              <div>💡</div>
-              <span className="text-xs">{state.brightness}%</span>
-            </div>
-            <div className="text-center">
-              <div>🌡️</div>
-              <span className="text-xs">{state.temperature}°F</span>
-            </div>
-            <div className="text-center">
-              <div>{state.notifications === 'quiet' ? '🔕' : '🔔'}</div>
-              <span className="text-xs">{state.notifications}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* AI Action */}
-      <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
-        <div className="flex items-start space-x-3">
-          <span>🤖</span>
-          <div>
-            <p className="text-sm font-medium text-purple-900">AI Action</p>
-            <p className="text-sm text-purple-700">{state.action}</p>
-          </div>
-        </div>
-      </div>
+      {step === 0 && <button onClick={() => setStep(1)}>See what it does for you</button>}
+      {step === 1 && <button onClick={() => setStep(2)}>Make it show its work</button>}
+      {step === 2 && <button onClick={() => setStep(0)}>Start over</button>}
     </div>
   );
 }`

--- a/src/data/patterns/patterns/collaborative-ai/code-examples.ts
+++ b/src/data/patterns/patterns/collaborative-ai/code-examples.ts
@@ -2,97 +2,47 @@ import { CodeExample } from '../../../../types';
 
 export const codeExamples: CodeExample[] = [
   {
-    title: "Collaborative AI Workspace",
-    description: "A simple example showing how AI can assist teams working together on shared documents by providing suggestions that anyone can apply.",
+    title: "A yes-man in the group chat vs. a real teammate",
+    description: "A team is converging on a risky call. A yes-man AI just piles on more agreement and the group barrels ahead; a real collaborator holds the context the team missed and helps them decide. Collaborative AI is a participant in the shared decision, not a cheerleader.",
     language: "tsx",
     componentId: "collaborative-ai-demo",
     code: `'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
-interface Suggestion {
-  id: string;
-  text: string;
-}
+type Step = 0 | 1 | 2;
 
-const teamMembers = ['Alice 👩‍💼', 'Bob 👨‍💻', 'You 👤'];
+// Collaborative AI is AI as a real participant in a TEAM's shared decision. The
+// yes-man trap bites in a group: three people already agree, the AI piles on,
+// and nobody fills the "wait, are we sure?" role. A real collaborator holds the
+// context the team missed and helps them decide.
+const TEAM = [
+  'Priya: Let us skip user testing and launch Friday',
+  'Marco: Love it, I am in!',
+  'Dev: Same — let us ship it.',
+];
 
-export default function CollaborativeAIDemo() {
-  const [document, setDocument] = useState('');
-  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+export default function CollaborativeAiDemo() {
+  const [step, setStep] = useState<Step>(0);
 
-  useEffect(() => {
-    // Generate AI suggestion when document has content
-    if (document.length > 20 && suggestions.length === 0) {
-      const timer = setTimeout(() => {
-        setSuggestions([
-          {
-            id: '1',
-            text: 'Consider adding specific examples to strengthen your points'
-          }
-        ]);
-      }, 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [document, suggestions.length]);
-
-  const applySuggestion = (id: string) => {
-    const suggestion = suggestions.find(s => s.id === id);
-    if (suggestion) {
-      setDocument(prev => prev + ' [AI suggestion applied]');
-      setSuggestions(prev => prev.filter(s => s.id !== id));
-    }
-  };
-
-  const dismissSuggestion = (id: string) => {
-    setSuggestions(prev => prev.filter(s => s.id !== id));
-  };
+  const ai =
+    step === 1
+      ? 'Amazing plan, team — you have got this!' // yes-man: just more agreement
+      : step === 2
+        ? 'Before we lock it in: we have not tested signup, and Friday is our busiest day. Want me to flag the riskiest paths?' // real collaborator
+        : '';
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-4">
-      <div>
-        <h2 className="text-2xl font-bold mb-2">Team Document</h2>
-        <p className="text-gray-600">Collaborate with your team and get AI suggestions</p>
-      </div>
+    <div>
+      {TEAM.map((line, i) => (
+        <p key={i}>{line}</p>
+      ))}
 
-      <div className="flex gap-2 items-center">
-        <span className="text-sm text-gray-600">Team:</span>
-        {teamMembers.map((member, i) => (
-          <span key={i} className="text-sm">{member}</span>
-        ))}
-      </div>
+      {step >= 1 && <p>AI teammate: {ai}</p>}
 
-      <textarea
-        value={document}
-        onChange={(e) => setDocument(e.target.value)}
-        placeholder="Start typing to collaborate... AI will suggest improvements"
-        className="w-full h-40 p-4 border rounded-lg resize-none"
-      />
-
-      {suggestions.length > 0 && (
-        <div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
-          <h3 className="font-semibold text-purple-900 mb-3">🤖 AI Suggestion</h3>
-          {suggestions.map(suggestion => (
-            <div key={suggestion.id} className="space-y-2">
-              <p className="text-sm text-gray-700">{suggestion.text}</p>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => applySuggestion(suggestion.id)}
-                  className="px-3 py-1 bg-purple-600 text-white text-sm rounded hover:bg-purple-700"
-                >
-                  Apply
-                </button>
-                <button
-                  onClick={() => dismissSuggestion(suggestion.id)}
-                  className="px-3 py-1 bg-gray-200 text-gray-700 text-sm rounded hover:bg-gray-300"
-                >
-                  Dismiss
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      {step === 0 && <button onClick={() => setStep(1)}>See what the AI adds</button>}
+      {step === 1 && <button onClick={() => setStep(2)}>Make it a real collaborator</button>}
+      {step === 2 && <button onClick={() => setStep(0)}>Start over</button>}
     </div>
   );
 }`


### PR DESCRIPTION
## What

Rebuilds two more pattern-page demos so they **embody the pattern's trap** instead of teaching the anti-pattern, in plain language for designers/founders. Continues the demo-rebuild effort tracked in `docs/PATTERN-REDO-TRACKER.md` (this brings the flagged set to **4 / 5**).

### collaborative-ai — *a team yes-man vs. a real collaborator*
A group is converging fast on a risky launch call. Step 1 shows the AI piling on more agreement (the yes-man trap — makes a risky plan feel unanimous). Step 2 shows a real collaborator holding the context the team missed and helping them decide.

### ambient-intelligence — *the surveillance hum vs. ambient that shows its work*
Replaces the old always-on time-slider (which romanticized silent monitoring). Step 1 embodies the surveillance hum: the AI acts on signals the user never offered (an overheard call, how tense they sounded, who walked in) with no trace. Step 2 inverts it: acts only on signals the user handed it, logging every change with a reason + undo + pause.

## Recipe compliance (both)
- Guided 2-step trap → resolution; plain language, no dev jargon
- Semantic tokens only, no `dark:` variants — `brand:check` = 0
- Dead-click-safe: inert mock chips are `pointer-events-none`; only the stepping `<Button>` is interactive (verified 0 interactive Undo roles via Playwright)
- Readable type, `aria-live` step announcements
- Paired `code-examples.ts` regenerated to match each component

## Verification
- `brand:check` passes (0 violations)
- Live Playwright pass through 0 → 1 → 2 → reset on both demos: correct content per step, no console errors
- `tsc` clean for the touched files (pre-existing unrelated errors elsewhere)

## Scope
5 files: the two demo components, their two `code-examples.ts`, and the tracker. No other changes.