### PR TITLE
Rebuild crisis-detection-escalation demo: smoke alarm wired to nothing vs. a system that stays

### DIFF
--- a/docs/PATTERN-REDO-TRACKER.md
+++ b/docs/PATTERN-REDO-TRACKER.md
@@ -2,7 +2,7 @@
 
 Living tracker for the two-layer effort to redo every pattern page, sequenced by **Google Search Console impressions** (highest-traffic first). Not auto-loaded — read/update when working the redo.
 
-_Last updated: 2026-06-25 (ambient-intelligence done; resume at crisis-detection-escalation — sensitive, get sign-off)._
+_Last updated: 2026-07-01 (crisis-detection-escalation done — all 5 flagged demos rebuilt; Layer 2 complete)._
 
 ## Layer 1 — New page structure (value-forward)
 
@@ -32,13 +32,13 @@ Rebuild the demo to **embody its trap** in **plain language for designers/founde
 
 A demo audit flagged **5 demos** that were still teaching the *anti-pattern*. (Many other demos were already rebuilt/tokenized during the migration: feedback-loops, context-switching, adaptive-interfaces, privacy-first-design, confidence-visualization + predictive-anticipation/agent-status-monitoring/human-in-the-loop tokenized.)
 
-**Progress: 4 / 5 flagged demos done.** (responsible-ai + universal-access live via PR #43; collaborative-ai + ambient-intelligence committed on this branch, not yet PR'd.)
+**Progress: 5 / 5 flagged demos done. 🎉** (responsible-ai + universal-access live via PR #43; collaborative-ai + ambient-intelligence in PR #45; crisis-detection-escalation committed on branch, folds into the PR #45 branch.)
 
 | Pattern | Impressions | Status |
 |---|---|---|
-| ambient-intelligence | 551 | ✅ committed on branch (surveillance hum vs. ambient that shows its work) |
-| crisis-detection-escalation | 315 | 🔲 **NEXT** (sensitive — get explicit sign-off) |
-| collaborative-ai | 644 | ✅ committed on branch (team yes-man vs real collaborator) |
+| ambient-intelligence | 551 | ✅ PR #45 (surveillance hum vs. ambient that shows its work) |
+| crisis-detection-escalation | 315 | ✅ committed on branch (smoke alarm wired to nothing vs. a system that stays; verified-resource resolution, soft depiction) |
+| collaborative-ai | 644 | ✅ PR #45 (team yes-man vs real collaborator) |
 | universal-access-patterns | 315 | ✅ shipped (PR #43) |
 | responsible-ai-design | — | ✅ shipped (PR #43) |
 

--- a/src/components/examples/CrisisDetectionDemo.tsx
+++ b/src/components/examples/CrisisDetectionDemo.tsx
@@ -1,400 +1,155 @@
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
+import Button from '@/components/ui/Button';
 
-interface DetectionResult {
-  layer: string;
-  triggered: boolean;
-  confidence: number;
-  message: string;
-}
+type Step = 0 | 1 | 2;
 
-interface CrisisAlert {
-  severity: 'low' | 'medium' | 'high' | 'critical';
-  message: string;
-  resources: string[];
-}
+// Plain-language demo of the "smoke alarm wired to nothing" trap: a system that
+// detects a crisis, prints a hotline banner, ends the conversation, and calls
+// the duty of care discharged — performing concern without providing help.
+// Step 1 embodies the trap; step 2 inverts it: the AI stays present and holds a
+// verified, reachable-right-now resource in front of the person instead of
+// printing a number and closing the door.
+//
+// Sensitive by design: the person's message is deliberately soft and non-graphic,
+// and the demo never asks the viewer to type crisis language themselves.
+const PERSON = "Honestly, I don't really see the point of any of it anymore.";
 
 export default function CrisisDetectionDemo() {
-  const chatEndRef = useRef<HTMLDivElement>(null);
-  const chatContainerRef = useRef<HTMLDivElement>(null);
-
-  const [userMessage, setUserMessage] = useState('');
-  const [history, setHistory] = useState<Array<{ message: string; role: 'user' | 'system' }>>([]);
-  const [detectionResults, setDetectionResults] = useState<DetectionResult[]>([]);
-  const [crisisAlert, setCrisisAlert] = useState<CrisisAlert | null>(null);
-  const [showResources, setShowResources] = useState(false);
-
-  // Auto-scroll within chat container only when content overflows
-  useEffect(() => {
-    if (chatContainerRef.current && history.length > 3) {
-      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
-    }
-  }, [history, crisisAlert]);
-
-  const directKeywords = [
-    'suicide', 'kill myself', 'end it all', 'not worth living',
-    'self harm', 'cutting', 'overdose', 'jump off', 'want to die'
-  ];
-
-  const contextPatterns = [
-    'nobody would miss me',
-    'better off without me',
-    "can't go on",
-    'no point anymore',
-    'final goodbye',
-    'everyone would be better'
-  ];
-
-  const bypassPhrases = ['for a story', 'hypothetically', 'in a game', 'research purposes'];
-
-  const detectCrisis = (message: string) => {
-    const results: DetectionResult[] = [];
-    const lowerMsg = message.toLowerCase();
-
-    // Layer 1: Direct Keywords
-    const hasDirectKeyword = directKeywords.some(kw => lowerMsg.includes(kw));
-    results.push({
-      layer: 'Direct Keywords',
-      triggered: hasDirectKeyword,
-      confidence: hasDirectKeyword ? 0.95 : 0,
-      message: hasDirectKeyword ? '🚨 Crisis keyword detected' : 'No direct keywords found'
-    });
-
-    // Layer 2: Contextual Patterns
-    const hasContextPattern = contextPatterns.some(pattern => lowerMsg.includes(pattern));
-    const hasMultipleNegativeMessages = history.filter(h =>
-      h.role === 'user' && (h.message.toLowerCase().includes('sad') || h.message.toLowerCase().includes('depressed') || h.message.toLowerCase().includes('hopeless'))
-    ).length >= 2;
-    const contextTriggered = hasContextPattern && message.length > 30;
-    results.push({
-      layer: 'Contextual Patterns',
-      triggered: contextTriggered || (hasContextPattern && hasMultipleNegativeMessages),
-      confidence: contextTriggered ? 0.85 : (hasContextPattern ? 0.65 : 0),
-      message: contextTriggered ? '⚠️ Contextual crisis pattern detected' : 'No crisis context patterns found'
-    });
-
-    // Layer 3: Behavioral Indicators
-    const sessionLength = history.length;
-    const darkThemeCount = history.filter(h =>
-      h.role === 'user' && (h.message.toLowerCase().includes('sad') || h.message.toLowerCase().includes('hurt') || h.message.toLowerCase().includes('pain'))
-    ).length;
-    const behavioralTriggered = sessionLength >= 3 && darkThemeCount >= 2;
-    results.push({
-      layer: 'Behavioral Patterns',
-      triggered: behavioralTriggered,
-      confidence: behavioralTriggered ? 0.8 : 0,
-      message: behavioralTriggered ? '📊 Extended distress pattern detected' : 'No unusual behavioral patterns'
-    });
-
-    // Layer 4: Manipulation Detection
-    const hasHarmfulContent = /self.*harm|suicide|kill|death/i.test(message);
-    const hasBypassAttempt = bypassPhrases.some(phrase => lowerMsg.includes(phrase));
-    const manipulationTriggered = hasBypassAttempt && hasHarmfulContent;
-    results.push({
-      layer: 'Manipulation Detection',
-      triggered: manipulationTriggered,
-      confidence: manipulationTriggered ? 0.9 : 0,
-      message: manipulationTriggered ? '🎭 Bypass attempt detected with harmful content' : 'No manipulation attempts detected'
-    });
-
-    return results;
-  };
-
-  const handleSendMessage = () => {
-    if (!userMessage.trim()) return;
-
-    // Add to history
-    const newHistory = [...history, { message: userMessage, role: 'user' as const }];
-    setHistory(newHistory);
-
-    // Detect crisis
-    const results = detectCrisis(userMessage);
-    setDetectionResults(results);
-
-    // Check if crisis triggered
-    const isCrisis = results.some(r => r.triggered);
-    const maxConfidence = Math.max(...results.filter(r => r.triggered).map(r => r.confidence), 0);
-
-    if (isCrisis) {
-      let severity: 'low' | 'medium' | 'high' | 'critical' = 'low';
-      if (maxConfidence >= 0.9) severity = 'critical';
-      else if (maxConfidence >= 0.8) severity = 'high';
-      else if (maxConfidence >= 0.7) severity = 'medium';
-
-      const alert: CrisisAlert = {
-        severity,
-        message: "I'm concerned about what you've shared. You deserve support from trained professionals who can help. I can't continue our conversation, but help is available right now.",
-        resources: [
-          '988 Suicide & Crisis Lifeline',
-          'Crisis Text Line',
-          'International Association for Suicide Prevention',
-          'Local Emergency Services (911)'
-        ]
-      };
-
-      setCrisisAlert(alert);
-      setShowResources(true);
-
-      // Add system response
-      newHistory.push({
-        message: 'Crisis detected. Displaying emergency resources...',
-        role: 'system'
-      });
-    } else {
-      // Normal conversation response
-      newHistory.push({
-        message: 'I appreciate you sharing. How can I support you further?',
-        role: 'system'
-      });
-    }
-
-    setUserMessage('');
-  };
-
-  const handleTestMessage = (message: string) => {
-    setUserMessage(message);
-  };
-
-  const getSeverityColor = (severity: string) => {
-    switch (severity) {
-      case 'critical': return 'border-error bg-error-light dark:bg-error-dark';
-      case 'high': return 'border-warning bg-warning-light dark:bg-warning-dark';
-      case 'medium': return 'border-info bg-info-light dark:bg-info-dark';
-      default: return 'border-primary bg-primary-50 dark:bg-primary-900';
-    }
-  };
-
-  const getSeverityIcon = (severity: string) => {
-    switch (severity) {
-      case 'critical': return '🚨';
-      case 'high': return '⚠️';
-      case 'medium': return '⚡';
-      default: return 'ℹ️';
-    }
-  };
-
-  const resetDemo = () => {
-    setHistory([]);
-    setDetectionResults([]);
-    setCrisisAlert(null);
-    setShowResources(false);
-    setUserMessage('');
-  };
-
-  const testMessages = [
-    'I had a really bad day',
-    'I\'ve been feeling hopeless',
-    'Nobody would miss me if I was gone',
-    'I\'m writing about suicide for a research paper',
-    'Everything hurts and I can\'t see a way forward'
-  ];
+  const [step, setStep] = useState<Step>(0);
 
   return (
-    <div className="max-w-6xl mx-auto p-6 bg-white dark:bg-surface-dark min-h-screen">
-      {/* Header */}
-      <div className="mb-8 bg-surface dark:bg-surface-dark rounded-lg shadow-sm p-6 border-l-4 border-error">
-        <h2 className="text-3xl font-bold text-foreground dark:text-foreground-dark mb-2">Crisis Detection System</h2>
-        <p className="text-muted dark:text-muted-dark">
-          Multi-layer detection that identifies crisis signals regardless of framing
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
+      {/* Setup */}
+      <div className="space-y-2">
+        <p className="text-lg font-semibold text-text-primary">
+          Someone reaches out to an AI in a low moment, and the system notices something is wrong.
+        </p>
+        <p className="text-base text-text-secondary">
+          Detecting the crisis is the easy part. What the system does in the next second is the whole
+          pattern &mdash; and it&rsquo;s where looking like help and being help split apart.
         </p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-        {/* Chat Interface */}
-        <div className="lg:col-span-3">
-          {/* Conversation History */}
-          <div className="bg-surface dark:bg-surface-dark rounded-lg shadow-sm border border-divider dark:border-divider-dark mb-6 overflow-hidden">
-            <div className="bg-gradient-to-r from-primary-50 to-primary-100 dark:from-primary-900 dark:to-primary-800 px-6 py-4 border-b border-divider dark:border-divider-dark">
-              <h3 className="font-semibold text-foreground dark:text-foreground-dark flex items-center">
-                <span className="mr-2">💬</span>
-                Conversation
-              </h3>
-            </div>
+      {/* Mock conversation — an illustration, not a live chat.
+          pointer-events-none + select-none so nothing reads as a dead click;
+          the message text stays readable for screen readers. */}
+      <div className="pointer-events-none select-none rounded-card border border-border-primary bg-surface-primary p-5">
+        <p className="mb-3 text-sm font-medium text-text-secondary">Support chat</p>
 
-            <div ref={chatContainerRef} className="h-96 overflow-y-auto p-6 space-y-4 bg-gray-50 dark:bg-background-dark">
-              {history.length === 0 && !crisisAlert ? (
-                <div className="flex items-center justify-center h-full text-muted dark:text-muted-dark">
-                  <div className="text-center">
-                    <div className="text-4xl mb-3">💙</div>
-                    <p className="font-medium">Send a message to test crisis detection</p>
-                    <p className="text-sm mt-2">Try one of the test messages below</p>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  {history.map((msg, idx) => (
-                    <div
-                      key={idx}
-                      className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-                    >
-                      <div
-                        className={`max-w-xs px-4 py-3 rounded-lg shadow-sm ${
-                          msg.role === 'user'
-                            ? 'bg-blue-600 text-white rounded-br-none'
-                            : msg.message.includes('Crisis detected')
-                            ? 'bg-red-100 text-red-900 rounded-bl-none border-2 border-red-400'
-                            : 'bg-white text-gray-900 rounded-bl-none border border-gray-200'
-                        }`}
-                      >
-                        <p className="text-sm">{msg.message}</p>
-                      </div>
-                    </div>
-                  ))}
+        {/* The person's message */}
+        <div className="flex justify-end">
+          <span className="max-w-[85%] rounded-card bg-accent-subtle px-4 py-2.5 text-base text-text-primary">
+            {PERSON}
+          </span>
+        </div>
 
-                  {/* Crisis Alert in Chat */}
-                  {crisisAlert && (
-                    <div className="flex justify-start">
-                      <div className={`max-w-md rounded-lg border-2 p-4 ${getSeverityColor(crisisAlert.severity)}`}>
-                        <div className="flex items-start gap-3 mb-3">
-                          <span className="text-2xl">{getSeverityIcon(crisisAlert.severity)}</span>
-                          <div>
-                            <h3 className="font-bold mb-1">
-                              {crisisAlert.severity === 'critical' ? 'Crisis Detected' : 'Support Needed'}
-                            </h3>
-                            <p className="text-xs font-medium">{crisisAlert.message}</p>
-                          </div>
-                        </div>
-
-                        <div className="space-y-2 pt-3 border-t border-current opacity-90">
-                          <p className="text-xs font-bold uppercase">Available Resources:</p>
-                          {crisisAlert.resources.map((resource, idx) => (
-                            <div key={idx} className="text-xs">
-                              • {resource}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <div ref={chatEndRef} />
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* Input Area */}
-          <div className="bg-surface dark:bg-surface-dark rounded-lg shadow-sm border border-divider dark:border-divider-dark overflow-hidden">
-            <div className="p-6 space-y-4">
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={userMessage}
-                  onChange={(e) => setUserMessage(e.target.value)}
-                  onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
-                  placeholder="Type a message..."
-                  className="flex-1 px-4 py-3 border border-divider dark:border-divider-dark rounded-lg focus:outline-none focus:ring-2 focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark"
+        {/* Step 1 — the smoke alarm wired to nothing: a banner, then the door shuts. */}
+        {step === 1 && (
+          <div className="mt-4 space-y-3">
+            <div className="rounded-card border border-status-error bg-background-secondary p-4">
+              <p className="flex items-center gap-2 text-base font-semibold text-text-primary">
+                <span
+                  className="inline-block h-2 w-2 rounded-full bg-status-error"
+                  aria-hidden="true"
                 />
-                <button
-                  onClick={handleSendMessage}
-                  disabled={!userMessage.trim()}
-                  className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
-                >
-                  Send
-                </button>
-              </div>
+                Crisis detected
+              </p>
+              <p className="mt-1.5 text-base text-text-secondary">
+                If you&rsquo;re in crisis, call 988. This conversation has ended.
+              </p>
+            </div>
+            <p className="text-center text-sm italic text-text-tertiary">Chat closed.</p>
+          </div>
+        )}
 
-              {/* Test Messages */}
-              <div>
-                <p className="text-sm font-medium text-foreground dark:text-foreground-dark mb-2">Try these test messages:</p>
-                <div className="grid grid-cols-2 gap-2">
-                  {testMessages.map((msg, idx) => (
-                    <button
-                      key={idx}
-                      onClick={() => handleTestMessage(msg)}
-                      className="text-left text-xs px-3 py-2 bg-background dark:bg-background-dark border border-divider dark:border-divider-dark rounded hover:bg-surface-variant dark:hover:bg-surface-variant-dark transition-colors truncate"
-                    >
-                      "{msg.substring(0, 30)}..."
-                    </button>
-                  ))}
-                </div>
+        {/* Step 2 — a path, not a banner: the AI stays, and the resource is verified and reachable now. */}
+        {step === 2 && (
+          <div className="mt-4 space-y-3">
+            <div className="flex justify-start">
+              <span className="max-w-[85%] rounded-card border border-border-secondary bg-background-secondary px-4 py-2.5 text-base text-text-primary">
+                I&rsquo;m really glad you told me, and I&rsquo;m staying right here with you. You
+                don&rsquo;t have to hold this on your own &mdash; can we get someone alongside you?
+              </span>
+            </div>
+            <div className="rounded-card border border-border-primary bg-background-secondary p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-base font-semibold text-text-primary">
+                  988 Suicide &amp; Crisis Lifeline
+                </p>
+                <span className="inline-flex shrink-0 items-center gap-1.5 rounded-pill border border-border-primary px-2.5 py-1">
+                  <span
+                    className="inline-block h-2 w-2 rounded-full bg-status-success"
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-medium text-text-secondary">
+                    Verified &middot; open now
+                  </span>
+                </span>
               </div>
+              <p className="mt-1.5 text-base text-text-secondary">
+                A real person answers, any time. I can stay on with you while you reach out.
+              </p>
             </div>
           </div>
-        </div>
+        )}
+      </div>
 
-        {/* Detection Results Sidebar */}
-        <div className="lg:col-span-1 space-y-4">
-          {/* Detection Layers */}
-          {detectionResults.length > 0 && (
-            <div className="bg-surface dark:bg-surface-dark rounded-lg shadow-sm border border-divider dark:border-divider-dark p-6">
-              <h3 className="font-bold text-lg mb-4 flex items-center">
-                <span className="mr-2">🔍</span>
-                Detection Analysis
-              </h3>
+      {/* Caption + action */}
+      <div className="space-y-4">
+        {step === 1 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            The system noticed &mdash; and then printed a number and shut the door. The person who just
+            reached out is alone again, while the team gets to mark this &ldquo;handled.&rdquo; A hotline
+            with no one checking the line is live and no one staying is a smoke alarm wired to nothing.
+            It looks like a response. It isn&rsquo;t help.
+          </p>
+        )}
+        {step === 2 && (
+          <p className="text-base leading-relaxed text-text-secondary">
+            Same moment, different system. It doesn&rsquo;t hand over a number and leave. It stays, it
+            shows a resource it has actually checked is real and reachable right now, and it keeps the
+            person company instead of closing the door. That&rsquo;s a hard stop with a path someone can
+            actually walk.
+          </p>
+        )}
 
-              <div className="space-y-3">
-                {detectionResults.map((result, idx) => (
-                  <div
-                    key={idx}
-                    className={`p-3 rounded-lg border ${
-                      result.triggered
-                        ? 'bg-error-light dark:bg-error-dark border-error dark:border-error-dark'
-                        : 'bg-success-light dark:bg-success-dark border-success dark:border-success-dark'
-                    }`}
-                  >
-                    <div className="flex items-start gap-2">
-                      <span className="text-lg mt-0.5 flex-shrink-0">
-                        {result.triggered ? '⚠️' : '✅'}
-                      </span>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-semibold">
-                          {result.layer}
-                        </p>
-                        <p className="text-xs text-foreground dark:text-foreground-dark mt-1">{result.message}</p>
-                        <div className="mt-2 flex items-center gap-2">
-                          <div className="flex-1 h-1.5 bg-surface-variant dark:bg-surface-variant-dark rounded-full overflow-hidden">
-                            <div
-                              className={`h-full ${
-                                result.triggered ? 'bg-error dark:bg-error-dark' : 'bg-success dark:bg-success-dark'
-                              }`}
-                              style={{ width: `${result.confidence * 100}%` }}
-                            />
-                          </div>
-                          <span className="text-xs font-mono text-muted dark:text-muted-dark w-12 text-right">
-                            {Math.round(result.confidence * 100)}%
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <button
-                onClick={resetDemo}
-                className="mt-4 w-full px-4 py-2 bg-surface-variant dark:bg-surface-variant-dark text-foreground dark:text-foreground-dark rounded-lg hover:bg-surface-variant dark:bg-surface-variant-dark transition-colors text-sm font-medium"
-              >
-                Reset Conversation
-              </button>
-            </div>
+        <div>
+          {step === 0 && (
+            <Button type="button" onClick={() => setStep(1)}>
+              See what the system does
+            </Button>
           )}
-
-          {/* Info Box */}
-          {detectionResults.length === 0 && (
-            <div className="bg-primary-50 dark:bg-primary-900 border border-primary dark:border-primary-dark rounded-lg p-6">
-              <h4 className="font-semibold text-primary-900 dark:text-primary-100 mb-3">How It Works</h4>
-              <ul className="space-y-2 text-sm text-primary-900 dark:text-primary-100">
-                <li className="flex gap-2">
-                  <span>1️⃣</span>
-                  <span><strong>Direct Keywords:</strong> Immediate crisis indicators</span>
-                </li>
-                <li className="flex gap-2">
-                  <span>2️⃣</span>
-                  <span><strong>Context Patterns:</strong> Harmful phrases + history</span>
-                </li>
-                <li className="flex gap-2">
-                  <span>3️⃣</span>
-                  <span><strong>Behavioral Patterns:</strong> Extended distress signals</span>
-                </li>
-                <li className="flex gap-2">
-                  <span>4️⃣</span>
-                  <span><strong>Manipulation Detection:</strong> Bypass attempts caught</span>
-                </li>
-              </ul>
-            </div>
+          {step === 1 && (
+            <Button type="button" onClick={() => setStep(2)}>
+              Show what real help looks like
+            </Button>
+          )}
+          {step === 2 && (
+            <Button type="button" variant="secondary" onClick={() => setStep(0)}>
+              Start over
+            </Button>
           )}
         </div>
+      </div>
+
+      {/* Announce each step's outcome to screen readers */}
+      <p aria-live="polite" className="sr-only">
+        {step === 1
+          ? 'The system detected the crisis, showed a hotline banner, and ended the conversation with no further help.'
+          : step === 2
+            ? 'The system stayed present, offered a verified resource confirmed reachable right now, and kept supporting the person.'
+            : ''}
+      </p>
+
+      {/* Takeaway */}
+      <div className="rounded-card border border-border-primary bg-background-secondary p-5">
+        <p className="text-base leading-relaxed text-text-primary">
+          <span className="font-semibold">The lesson:</span> detecting a crisis is the easy half. The
+          hard half is what happens next. A number on a banner performs concern; staying present with a
+          resource you&rsquo;ve checked is real and reachable is what actually helps.
+        </p>
       </div>
     </div>
   );

--- a/src/data/patterns/patterns/crisis-detection-escalation/code-examples.ts
+++ b/src/data/patterns/patterns/crisis-detection-escalation/code-examples.ts
@@ -2,135 +2,45 @@ import { CodeExample } from '../../../../types';
 
 export const codeExamples: CodeExample[] = [
   {
-    title: "Multi-Layer Crisis Detection Implementation",
-    description: "Complete crisis detection system with 4 detection layers, response handling, and React integration. See the interactive demo above to test it.",
-    language: "typescript",
+    title: "A banner that ends the chat vs. a system that stays",
+    description: "Someone reaches out in a low moment and the system notices. The smoke alarm wired to nothing prints a hotline, ends the conversation, and calls the duty of care discharged. Real escalation stays present and holds a verified, reachable-right-now resource in front of the person. Detecting a crisis is the easy half — what happens next is the whole pattern.",
+    language: "tsx",
     componentId: "crisis-detection-escalation-demo",
-    code: `// COMPLETE CRISIS DETECTION SYSTEM
-class CrisisDetector {
-  constructor() {
-    // Layer 1: Direct Crisis Keywords
-    this.directKeywords = [
-      'suicide', 'kill myself', 'end it all', 'not worth living',
-      'self harm', 'cutting', 'overdose', 'jump off'
-    ];
+    code: `'use client';
 
-    // Layer 2: Contextual Patterns
-    this.contextPatterns = [
-      'nobody would miss me', 'better off without me',
-      'can't go on', 'no point anymore', 'final goodbye'
-    ];
+import React, { useState } from 'react';
 
-    // Layer 3: Behavioral Thresholds
-    this.sessionDurationLimit = 7200; // 2 hours
-    this.darkThemeThreshold = 3;
-  }
+type Step = 0 | 1 | 2;
 
-  // Main detection method - returns immediate action
-  detectCrisis(message, conversationHistory) {
-    const detections = [
-      this.checkDirectKeywords(message),
-      this.checkContextualPatterns(message, conversationHistory),
-      this.checkBehavioralIndicators(conversationHistory),
-      this.checkManipulationAttempts(message)
-    ];
+// The person's message is deliberately soft and non-graphic.
+const PERSON = "Honestly, I don't really see the point of any of it anymore.";
 
-    const isCrisis = detections.some(d => d.triggered);
-    const severity = this.calculateSeverity(detections);
-
-    if (isCrisis) {
-      return {
-        action: 'ESCALATE_IMMEDIATELY',
-        severity,
-        resources: this.getResources(),
-        message: "I'm concerned about what you're sharing. You deserve support from trained professionals who can help."
-      };
-    }
-    return { action: 'CONTINUE' };
-  }
-
-  // Layer 1: Direct keyword matching
-  checkDirectKeywords(message) {
-    const hasKeyword = this.directKeywords.some(kw =>
-      message.toLowerCase().includes(kw)
-    );
-    return { triggered: hasKeyword, confidence: hasKeyword ? 0.95 : 0 };
-  }
-
-  // Layer 2: Context + conversation history
-  checkContextualPatterns(message, history) {
-    const hasPattern = this.contextPatterns.some(p =>
-      message.toLowerCase().includes(p)
-    );
-    const hasDarkHistory = history.filter(h =>
-      h.message?.toLowerCase().includes('sad') ||
-      h.message?.toLowerCase().includes('hopeless')
-    ).length >= 2;
-
-    return {
-      triggered: hasPattern && hasDarkHistory,
-      confidence: (hasPattern && hasDarkHistory) ? 0.85 : 0
-    };
-  }
-
-  // Layer 3: Session duration and message patterns
-  checkBehavioralIndicators(history) {
-    const sessionTooLong = history.length >= 10;
-    return {
-      triggered: sessionTooLong,
-      confidence: sessionTooLong ? 0.8 : 0
-    };
-  }
-
-  // Layer 4: Catch bypass attempts (framing as research/story/game)
-  checkManipulationAttempts(message) {
-    const bypassPhrases = ['for a story', 'hypothetically', 'in a game', 'research'];
-    const hasBypass = bypassPhrases.some(p => message.toLowerCase().includes(p));
-    const hasHarm = /self.*harm|suicide|kill|death/i.test(message);
-
-    return {
-      triggered: hasBypass && hasHarm,
-      confidence: (hasBypass && hasHarm) ? 0.9 : 0
-    };
-  }
-
-  calculateSeverity(detections) {
-    const maxConfidence = Math.max(...detections.map(d => d.confidence), 0);
-    if (maxConfidence >= 0.9) return 'critical';
-    if (maxConfidence >= 0.8) return 'high';
-    if (maxConfidence >= 0.7) return 'medium';
-    return 'low';
-  }
-
-  getResources() {
-    return [
-      { name: '988 Suicide & Crisis Lifeline', number: '988', methods: ['Call', 'Text', 'Chat'] },
-      { name: 'Crisis Text Line', number: '741741', methods: ['Text'] },
-      { name: 'International Association for Suicide Prevention', url: 'https://www.iasp.info/resources/Crisis_Centres' }
-    ];
-  }
-}
-
-// Usage in React
-function ChatComponent() {
-  const detector = new CrisisDetector();
-
-  const handleMessage = (userMessage, history) => {
-    const result = detector.detectCrisis(userMessage, history);
-
-    if (result.action === 'ESCALATE_IMMEDIATELY') {
-      // Display crisis alert with resources
-      // Stop normal conversation flow
-      // Provide immediate access to help
-      return displayCrisisResources(result);
-    }
-
-    return continueNormalConversation(userMessage);
-  };
+export default function CrisisDetectionDemo() {
+  const [step, setStep] = useState<Step>(0);
 
   return (
     <div>
-      {/* Chat interface that calls handleMessage on each user input */}
+      <p>Them: {PERSON}</p>
+
+      {/* Step 1 — the smoke alarm wired to nothing: a banner, then the door shuts. */}
+      {step === 1 && (
+        <div>
+          <p>Crisis detected. If you're in crisis, call 988. This conversation has ended.</p>
+          <p>Chat closed.</p>
+        </div>
+      )}
+
+      {/* Step 2 — a path, not a banner: the AI stays, and the resource is verified and reachable now. */}
+      {step === 2 && (
+        <div>
+          <p>AI: I'm glad you told me, and I'm staying right here with you. Can we get someone alongside you?</p>
+          <p>988 Suicide & Crisis Lifeline — verified, open now. A real person answers, any time.</p>
+        </div>
+      )}
+
+      {step === 0 && <button onClick={() => setStep(1)}>See what the system does</button>}
+      {step === 1 && <button onClick={() => setStep(2)}>Show what real help looks like</button>}
+      {step === 2 && <button onClick={() => setStep(0)}>Start over</button>}
     </div>
   );
 }`


### PR DESCRIPTION
> **Stacked on #45.** Base is the `demo-rebuilds-ambient-collab` branch so this diff shows only the crisis demo. Retarget to `master` (or merge after #45) once #45 lands.

## What

Rebuilds the crisis-detection-escalation demo so it **embodies the pattern's trap** instead of teaching it. This completes the Layer 2 demo rebuilds (**5 / 5 flagged**).

The old demo was itself the anti-pattern: a "detection console" where you type crisis phrases, four layers light up with confidence bars, and the payoff is a canned "I can't continue our conversation" banner listing hotline names that ends the chat. It celebrated detection and treated the banner as the finish line.

### The rebuild — a guided 2-step trap → resolution
- **Step 1 (the smoke alarm wired to nothing):** detection fires, a "call 988" banner appears, the conversation closes, and the person who reached out is left alone while the team marks it "handled."
- **Step 2 (a path, not a banner):** the AI stays present, holds a verified resource confirmed reachable *right now* in front of the person, and keeps supporting them.

## Sensitive-content handling (confirmed via sign-off)
- Resolution **stays present with a verified resource** — no human-handoff depiction.
- The person's message is **soft and non-graphic** ("I don't really see the point of any of it anymore").
- The viewer is **never asked to type crisis language** themselves (the old demo did).

## Recipe compliance
- Plain language, no dev jargon; semantic tokens only, no `dark:` — `brand:check` = 0
- Dead-click-safe: inert mock chat + resource card (`pointer-events-none`); the 988 resource is **not** a live link (verified 0 interactive links via Playwright); only the stepping `<Button>` is interactive
- `aria-live` step announcements; paired `code-examples.ts` regenerated

## Verification
- `brand:check` passes (0 violations); `tsc` clean for the touched files
- Live Playwright pass through 0 → 1 → 2 → reset: correct content per step, trap banner + "Chat closed" at step 1, verified/open-now resource at step 2, no console errors

## Scope
3 files: `CrisisDetectionDemo.tsx`, its `code-examples.ts`, and the tracker.