### PR TITLE
fix(audit): stamp session id on funnel events (UiEvent.sessionId was always null)

### DIFF
--- a/src/components/audit/AuditClient.tsx
+++ b/src/components/audit/AuditClient.tsx
@@ -10,7 +10,7 @@ import { DEMO_ANALYSIS_RESULTS, DEMO_SCREENSHOT_FALLBACK } from '@/data/demo-aud
 import { RemainingAuditsBanner } from '@/components/audit/RemainingAuditsBanner';
 import { useAuditCount } from '@/hooks/useAuditCount';
 import type { AnalysisResults, AuditStep, ProductType } from '@/types/audit';
-import { trackAuditEvent } from '@/lib/audit/analytics';
+import { trackAuditEvent, setAuditSessionId } from '@/lib/audit/analytics';
 
 // Lazy load heavy components that aren't needed on initial paint
 
@@ -91,6 +91,7 @@ export default function AuditClient({
     }
     setIsDemoMode(false);
     setAnalysisResults(null);
+    setAuditSessionId(null);
     setUploadedImages([]);
     setProductType(null);
     setStep('screenshot');
@@ -149,6 +150,10 @@ export default function AuditClient({
       }
 
       setAnalysisResults(data as AnalysisResults);
+      // Stamp every subsequent results-page event (CTAs, chat, gap links) with
+      // this audit's id so the funnel is session-attributable. Must be set before
+      // the audit_session_completed / audit_gap_found events fire below.
+      setAuditSessionId((data as AnalysisResults).id ?? null);
       // Only burn a free-audit credit when the run actually surfaced findings.
       // Empty runs (the audit returned no applicable gaps — usually because the
       // screenshot isn't an AI product surface) shouldn't count against the
@@ -210,6 +215,7 @@ export default function AuditClient({
     }
     setUploadedImages([]);
     setAnalysisResults(null);
+    setAuditSessionId(null);
     setIsAnalyzing(false);
     setIsDemoMode(false);
     setStep('screenshot');
@@ -236,6 +242,9 @@ export default function AuditClient({
   // Fire demo-viewed analytics once on mount when landing on demo
   useEffect(() => {
     if (step === 'demo') {
+      // Fresh demo view — ensure no stale real-audit session id leaks onto
+      // demo events if this mounts after a prior audit in the same SPA session.
+      setAuditSessionId(null);
       trackAuditEvent('audit_demo_viewed', {
         source:
           typeof window !== 'undefined' && window.location.pathname === '/'
@@ -286,6 +295,7 @@ export default function AuditClient({
                     deviceType: 'desktop',
                   }]);
                   setAnalysisResults(DEMO_ANALYSIS_RESULTS);
+                  setAuditSessionId(null);
                   setIsDemoMode(true);
                   setProductType(null);
                 }}

--- a/src/lib/audit/__tests__/analytics.test.ts
+++ b/src/lib/audit/__tests__/analytics.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for the audit funnel session-id stamping.
+ *
+ * Bug (fixed 2026-07-06): every UiEvent row had sessionId=null because the
+ * beacon only read properties.sessionId, which no results-page event passed —
+ * making "distinct sessions reaching results" and "audits with >=1 chat
+ * message" uncomputable. setAuditSessionId() now stamps the active audit's id
+ * onto every subsequent event.
+ */
+import { trackAuditEvent, setAuditSessionId } from '../analytics';
+
+// beaconEvent only runs in production and posts via navigator.sendBeacon, else
+// fetch. We force the fetch path and read the JSON body it would have sent.
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function lastBeaconPayload(fetchMock: jest.Mock): Record<string, unknown> | null {
+  if (fetchMock.mock.calls.length === 0) return null;
+  const [, init] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+  return JSON.parse((init as RequestInit).body as string);
+}
+
+describe('audit analytics session id', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    (process.env as { NODE_ENV?: string }).NODE_ENV = 'production';
+    setAuditSessionId(null);
+    // Force the fetch branch (no sendBeacon) and capture the payload.
+    (navigator as unknown as { sendBeacon?: unknown }).sendBeacon = undefined;
+    fetchMock = jest.fn(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    // Avoid the Clarity branch and localStorage noise.
+    (window as unknown as { clarity?: unknown }).clarity = undefined;
+  });
+
+  afterEach(() => {
+    (process.env as { NODE_ENV?: string }).NODE_ENV = ORIGINAL_NODE_ENV;
+    setAuditSessionId(null);
+    jest.restoreAllMocks();
+  });
+
+  it('omits sessionId when none is set (the pre-fix behavior, without the fix)', () => {
+    trackAuditEvent('audit_session_completed', { score: 20, gapsFound: 5 });
+    const payload = lastBeaconPayload(fetchMock);
+    expect(payload).not.toBeNull();
+    expect(payload!.name).toBe('audit_session_completed');
+    expect(payload!.sessionId).toBeUndefined();
+  });
+
+  it('stamps the active audit session id onto events that carry no explicit sessionId', () => {
+    setAuditSessionId('audit_abc123');
+    trackAuditEvent('audit_handoff_copied', { gapCount: 5 });
+    const payload = lastBeaconPayload(fetchMock);
+    expect(payload!.sessionId).toBe('audit_abc123');
+  });
+
+  it('prefers an explicit per-event sessionId over the active session', () => {
+    setAuditSessionId('audit_active');
+    trackAuditEvent('audit_chat_message_sent', { messageCount: 1, sessionId: 'audit_explicit' });
+    const payload = lastBeaconPayload(fetchMock);
+    expect(payload!.sessionId).toBe('audit_explicit');
+  });
+
+  it('clears the session id when the audit resets', () => {
+    setAuditSessionId('audit_abc123');
+    setAuditSessionId(null);
+    trackAuditEvent('audit_demo_viewed', { source: 'homepage' });
+    const payload = lastBeaconPayload(fetchMock);
+    expect(payload!.sessionId).toBeUndefined();
+  });
+});

--- a/src/lib/audit/analytics.ts
+++ b/src/lib/audit/analytics.ts
@@ -58,6 +58,19 @@ declare global {
   }
 }
 
+// The current audit's session id (= the analysis `results.id`). Set once when a
+// real analysis produces results so EVERY subsequent event — CTA clicks, chat,
+// per-gap links — is stamped with the same id without each call site threading
+// it through `properties`. Cleared when a new audit starts. This fixes the
+// funnel bug where `UiEvent.sessionId` was always null (no results-page event
+// passed `properties.sessionId`), which made "distinct sessions reaching
+// results" and "audits with >=1 chat message" uncomputable.
+let currentAuditSessionId: string | null = null;
+
+export function setAuditSessionId(id: string | null) {
+  currentAuditSessionId = id;
+}
+
 // Fire-and-forget beacon to our own event log. Best-effort: never throws into a
 // click handler. Mirrors the sendBeacon pattern in WebVitalsReporter.tsx. Only
 // runs in production so dev/self-test clicks don't pollute the funnel data.
@@ -70,8 +83,11 @@ function beaconEvent(event: AuditEvent, properties?: Record<string, unknown>) {
     } catch {
       /* private mode / blocked storage */
     }
-    const sessionId =
-      properties && typeof properties.sessionId === 'string' ? properties.sessionId : undefined;
+    // Prefer an explicit per-event sessionId; otherwise fall back to the active
+    // audit session so results-page events aren't stored with a null sessionId.
+    const explicitSessionId =
+      properties && typeof properties.sessionId === 'string' ? properties.sessionId : null;
+    const sessionId = explicitSessionId ?? currentAuditSessionId ?? undefined;
     const payload = JSON.stringify({
       name: event,
       properties: properties ?? null,


### PR DESCRIPTION
## Problem

Every `UiEvent` row was written with `sessionId = null`. `beaconEvent` in `analytics.ts` only derived the session id from `properties.sessionId`, but **no results-page event passes one** (`audit_session_completed` sends `{score, productType, gapsFound}`, `audit_handoff_copied` sends `{gapCount}`, etc.). 

Consequence: the two funnel metrics we actually want — **distinct sessions reaching results** and **audits with ≥1 chat message** — were *uncomputable by design*, not just data-starved. This surfaced while researching why post-results CTAs are near-dead: we literally can't attribute events to an audit.

## Fix

A module-level current-audit session id in `analytics.ts`:
- `setAuditSessionId(id)` is called with the analysis `results.id` when a real audit completes, and cleared (`null`) when a new audit starts or the demo view mounts.
- `beaconEvent` falls back to it, so **every** results-page event (CTAs, chat, gap links) is now session-attributable — without threading `sessionId` through ~15 call sites. An explicit `properties.sessionId` still wins.

The server route (`/api/events`) already read and stored top-level `sessionId` correctly — no change needed there.

## Tests

Adds `src/lib/audit/__tests__/analytics.test.ts` (force-added; `__tests__` is gitignored by repo convention, matching the existing audit tests). Locks four behaviors: omit when unset, stamp the active id, explicit-overrides-active, and clear-on-reset. All pass.

## Verification

- `npx tsc --noEmit` — no new errors in the touched files.
- `npx jest src/lib/audit/__tests__/analytics.test.ts` — 4/4 pass.
- Pre-commit hooks (brand check, design audit, hooks lint) passed.

## Note

The beacon only fires in production (`NODE_ENV === 'production'`), so end-to-end delivery of these events is best verified on prod after deploy — give it a few days of traffic, then `UiEvent.sessionId` should be populated on results-page rows.