### PR TITLE
perf(ai): enable Anthropic prompt caching on stable-prefix Claude calls

### DIFF
--- a/src/app/api/audit/chat/route.ts
+++ b/src/app/api/audit/chat/route.ts
@@ -207,7 +207,9 @@ export async function POST(request: NextRequest) {
     const response = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 512,
-      system: systemPrompt,
+      // The system prompt is stable for the life of an audit chat session, so
+      // every follow-up turn re-reads this prefix from cache instead of re-billing it.
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: claudeMessages,
     });
 

--- a/src/app/api/mentor/chat/route.ts
+++ b/src/app/api/mentor/chat/route.ts
@@ -311,7 +311,10 @@ export async function POST(request: NextRequest) {
     const response = await anthropic.messages.create({
       model: 'claude-sonnet-4-6',
       max_tokens: 1024,
-      system: systemPrompt,
+      // Stable within a mentor chat session (tools + system are identical every
+      // turn), so multi-turn conversations and the tool-use continuation below
+      // read this prefix from cache. Breakpoint on system also covers the tools.
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       tools: TOOL_DEFINITIONS,
       messages: claudeMessages,
     });

--- a/src/app/api/patterns/analyze/route.ts
+++ b/src/app/api/patterns/analyze/route.ts
@@ -187,7 +187,12 @@ export async function POST(request: NextRequest) {
       model: 'claude-sonnet-4-6',
       max_tokens: 4096,
       temperature: 0,
-      ...(systemPrompt ? { system: systemPrompt } : {}),
+      // Cache the large, static analysis rubric (36-pattern library + process +
+      // output format). It's identical for a given productType, so repeat audits
+      // and the eval harness (which loops many fixtures) read it from cache.
+      ...(systemPrompt
+        ? { system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }] }
+        : {}),
       messages: [
         {
           role: 'user',

--- a/tests/audit-evals/run.ts
+++ b/tests/audit-evals/run.ts
@@ -90,7 +90,9 @@ async function callAnalyze(opts: {
       model: ANALYZE_MODEL,
       max_tokens: 4096,
       temperature: 0,
-      system: systemPrompt,
+      // Same rubric as the production analyze route; the harness loops many
+      // fixtures per run, so fixtures sharing a productType reuse this cached prefix.
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## What

Turns on Anthropic **prompt caching** (`cache_control: {type: 'ephemeral'}`) across the app's Claude calls — but only where a reusable, floor-clearing stable prefix actually exists. This is the thing the [Console → Caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) page reports on (distinct from Next.js ISR/page caching, which we already use heavily).

## Cached (stable prefix ≥ model floor + genuine reuse)

| Call site | Prefix | Why it pays off |
|---|---|---|
| `patterns/analyze` | ~2–2.5K-token 36-pattern rubric | Stable per `productType`; also exercised in bulk by the eval harness |
| `audit/chat` | per-session system prompt | Stable for the life of a chat session → every follow-up turn reads from cache |
| `mentor/chat` (both calls) | system + static tools | Same; breakpoint on `system` also covers the static `tools` |
| `tests/audit-evals/run.ts` | same rubric as analyze | Harness loops many fixtures → real cross-request hits |

Breakpoints go on the **stable system prefix only**; volatile content (screenshot, per-turn message) stays in `messages` after the breakpoint, per the prefix-match rules.

## Deliberately NOT cached (documented in the commit)

- **Haiku 4.5 sites** (`classify-product`, `classifier`, `suggest-patterns`) — under Haiku's **4096-token** cache floor; `classifier.ts` already documents this as a proven no-op.
- **Small-prefix Sonnet calls** (`scaffolder` ~1.2–1.5K, `enricher`/social ~250 tok) — under Sonnet 4.6's **2048-token** floor.
- **No-`system` single-shot calls** (mentor annotate/actions/scan, newsletter, social LinkedIn/Reddit, eval judge) — unique prompt every call, nothing to reuse.
- `visionClassifier` already caches (the in-repo reference implementation).

## Honest ROI note

At current audit volume (~1–2/day, hours apart) the 5-minute TTL means few cross-request hits — the **within-session chat reuse** and the **eval-harness loop** are the real wins today. The change is safe/inert when a prefix misses or falls below the floor, and it future-proofs for higher volume. Verify via `usage.cache_read_input_tokens` once traffic flows.

## Verification
- `npx tsc --noEmit` — clean on all four touched files.
- Pre-commit hooks (brand check, design audit, hooks lint) passed.