### PR TITLE
fix(patterns): show live pattern count (38) on /patterns hero + metadata

### DIFF
--- a/src/app/patterns/page.tsx
+++ b/src/app/patterns/page.tsx
@@ -18,10 +18,10 @@ export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: {
-    absolute: '36 AI UX Design Patterns — A Framework for Designing AI Products',
+    absolute: `${patterns.length} AI UX Design Patterns — A Framework for Designing AI Products`,
   },
   description:
-    '36 AI UX design patterns documented from ChatGPT, Claude, GitHub Copilot, Midjourney, Figma, Linear, and 50+ shipped AI products. Each pattern has real examples, code demos, and implementation guidance — use them to design AI experiences users actually trust.',
+    `${patterns.length} AI UX design patterns documented from ChatGPT, Claude, GitHub Copilot, Midjourney, Figma, Linear, and 50+ shipped AI products. Each pattern has real examples, code demos, and implementation guidance — use them to design AI experiences users actually trust.`,
   keywords: [
     'AI UX patterns',
     'AI design patterns',
@@ -40,9 +40,9 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     url: `${siteConfig.url}/patterns`,
-    title: '36 AI UX Design Patterns — A Framework for Designing AI Products',
+    title: `${patterns.length} AI UX Design Patterns — A Framework for Designing AI Products`,
     description:
-      '36 AI UX design patterns from ChatGPT, Claude, GitHub Copilot, Midjourney, and 50+ shipped AI products. Real examples, code demos, implementation guidance.',
+      `${patterns.length} AI UX design patterns from ChatGPT, Claude, GitHub Copilot, Midjourney, and 50+ shipped AI products. Real examples, code demos, implementation guidance.`,
     siteName: siteConfig.name,
     images: [
       {
@@ -55,9 +55,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: '36 AI UX Design Patterns — A Framework for Designing AI Products',
+    title: `${patterns.length} AI UX Design Patterns — A Framework for Designing AI Products`,
     description:
-      '36 AI UX design patterns from ChatGPT, Claude, GitHub Copilot, Midjourney, and 50+ shipped AI products.',
+      `${patterns.length} AI UX design patterns from ChatGPT, Claude, GitHub Copilot, Midjourney, and 50+ shipped AI products.`,
     images: [`${siteConfig.url}/images/og/og-home.png`],
     creator: siteConfig.creator.twitter,
   },
@@ -84,7 +84,7 @@ const collectionPageJsonLd = {
   '@type': 'CollectionPage',
   name: 'AI UX Design Patterns',
   url: `${siteConfig.url}/patterns`,
-  description: '36 AI UX design patterns documented from 50+ real shipped AI products.',
+  description: `${patterns.length} AI UX design patterns documented from 50+ real shipped AI products.`,
   isPartOf: {
     '@type': 'WebSite',
     name: siteConfig.name,
@@ -141,7 +141,7 @@ export default function PatternsIndexPage() {
                 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
                 style={{ color: 'var(--text-hero)', textWrap: 'balance' }}
               >
-                36 AI UX Design Patterns
+                {patterns.length} AI UX Design Patterns
               </h1>
 
               <p className="text-2xl md:text-3xl text-text-secondary mb-12">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -127,7 +127,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })
   );
 
-  // Pattern pages - 36 AI design patterns
+  // Pattern pages - 38 AI design patterns
   const patternPages: MetadataRoute.Sitemap = patterns.map((pattern) => ({
     url: `${baseUrl}/patterns/${pattern.slug}`,
     lastModified: patternLastModified(pattern),


### PR DESCRIPTION
The `/patterns` hero and page metadata hardcoded **"36"** but the library now has **38** patterns. This wires the count to `patterns.length` so it's always correct and never goes stale again.

- Hero H1: `{patterns.length} AI UX Design Patterns`
- Page metadata (title, description, OG, Twitter, JSON-LD): all derive from `patterns.length`
- sitemap comment corrected to 38

**Scope note:** this is deliberately limited to the pattern *library* surfaces. The **audit tool** copy elsewhere (homepage, resources, mentor prompts) legitimately says "36" — the audit scores against a separate, curated 36-pattern detection list that excludes the agentic patterns (not screenshot-detectable). Those were intentionally left at 36.

Verified: `tsc --noEmit` 0 errors, hero renders "38 AI UX Design Patterns".