### PR TITLE
npx skills add: public aiux-skills repo, hero command swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install --with-deps chromium",
     "eval:audit": "TS_NODE_PROJECT=tsconfig.eval.json ts-node -r tsconfig-paths/register tests/audit-evals/run.ts",
+    "skills:sync": "TS_NODE_PROJECT=tsconfig.eval.json ts-node -r tsconfig-paths/register scripts/skills/sync-skills-repo.ts",
     "eval:corpus-check": "TS_NODE_PROJECT=tsconfig.eval.json ts-node -r tsconfig-paths/register tests/audit-evals/validate-corpus.ts",
     "optimize-images": "node scripts/assets/optimize-images.js",
     "convert-gifs": "node scripts/assets/convert-gifs-enhanced.js",

--- a/scripts/skills/sync-skills-repo.ts
+++ b/scripts/skills/sync-skills-repo.ts
@@ -42,7 +42,7 @@ function readme(): string {
     )
     .join('\n');
 
-  return `# AI UX Skills
+  return `# AIUX Skills for Claude Code
 
 ${patterns.length} Claude Code skills, one per AI UX design pattern, generated from [aiuxdesign.guide](${SITE}/?${UTM}).
 

--- a/scripts/skills/sync-skills-repo.ts
+++ b/scripts/skills/sync-skills-repo.ts
@@ -1,0 +1,127 @@
+/**
+ * Regenerates the public imsaif/aiux-skills repo from the pattern registry.
+ *
+ * The skills repo is a build artifact: never hand-edit it. This script owns
+ * every file in it (38 skill folders + README + LICENSE). Run after any
+ * pattern or skill-composer change, then commit and push the target repo.
+ *
+ * Usage:
+ *   npm run skills:sync -- /path/to/aiux-skills-checkout
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { patterns } from '@/data/patterns';
+import { composeSkillMd, skillName } from '@/lib/skills/composeSkill';
+
+const SITE = 'https://aiuxdesign.guide';
+const UTM = 'utm_source=github&utm_medium=skills-repo&utm_campaign=aiux-skills';
+
+const target = process.argv[2];
+if (!target || !fs.existsSync(target)) {
+  console.error('Usage: npm run skills:sync -- /path/to/aiux-skills-checkout');
+  process.exit(1);
+}
+
+/** The funnel travels inside the artifact: every skill links back. */
+function skillFooter(slug: string): string {
+  return [
+    '',
+    '---',
+    '',
+    `Generated from [aiuxdesign.guide](${SITE}/?${UTM}), a library of ${patterns.length} AI UX patterns from shipped products. Full pattern with examples and demos: [${SITE}/patterns/${slug}](${SITE}/patterns/${slug}?${UTM}). Not sure which patterns your product needs? [Run the free audit](${SITE}/audit?${UTM}).`,
+    '',
+  ].join('\n');
+}
+
+function readme(): string {
+  const bySkill = [...patterns].sort((a, b) => a.title.localeCompare(b.title));
+  const rows = bySkill
+    .map(
+      (p) =>
+        `| \`${skillName(p)}\` | ${p.title} | [pattern page](${SITE}/patterns/${p.slug}?${UTM}) |`
+    )
+    .join('\n');
+
+  return `# AI UX Skills
+
+${patterns.length} Claude Code skills, one per AI UX design pattern, generated from [aiuxdesign.guide](${SITE}/?${UTM}).
+
+A skill is persistent design guidance for your coding agent: install it once and it triggers on its own whenever your work matches, with no prompting. Each skill carries one pattern's judgment (the symptoms it applies to and the moves that make it real), distilled from how 50+ shipped AI products design their experiences.
+
+## Install
+
+All of them:
+
+\`\`\`bash
+npx skills add imsaif/aiux-skills
+\`\`\`
+
+Works with Claude Code, Cursor, GitHub Copilot, and every agent the [skills CLI](https://skills.sh) supports. Prefer a hand-picked set? [Browse and save skills on the site](${SITE}/skills?${UTM}) and download them as one pack.
+
+## New to skills?
+
+Free 6-lesson course (about 20 minutes), written for designers starting from zero: [Using AI UX Skills with Claude Code](${SITE}/guides/ai-ux-skills-guide?${UTM}).
+
+## The skills
+
+| Skill | Pattern | Learn more |
+|-------|---------|------------|
+${rows}
+
+## Which ones does your product need?
+
+Upload a screenshot of your AI interface and get scored against all ${patterns.length} patterns: [free AI UX audit](${SITE}/audit?${UTM}).
+
+Daily AI UX news and pattern insights: [newsletter](${SITE}/news?${UTM}).
+
+---
+
+This repo is generated from the pattern registry at aiuxdesign.guide. Do not edit files here by hand; changes land via the site's pattern data.
+`;
+}
+
+const LICENSE = `MIT License
+
+Copyright (c) ${new Date().getFullYear()} Imran Mohammed / aiuxdesign.guide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+// Remove previously generated skill folders so renames and deletions sync.
+for (const entry of fs.readdirSync(target)) {
+  if (entry.startsWith('aiux-')) {
+    fs.rmSync(path.join(target, entry), { recursive: true });
+  }
+}
+
+let written = 0;
+for (const pattern of patterns) {
+  const dir = path.join(target, skillName(pattern));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    composeSkillMd(pattern).trimEnd() + '\n' + skillFooter(pattern.slug)
+  );
+  written += 1;
+}
+
+fs.writeFileSync(path.join(target, 'README.md'), readme());
+fs.writeFileSync(path.join(target, 'LICENSE'), LICENSE);
+
+console.log(`Wrote ${written} skills + README + LICENSE to ${target}`);

--- a/scripts/skills/sync-skills-repo.ts
+++ b/scripts/skills/sync-skills-repo.ts
@@ -1,5 +1,5 @@
 /**
- * Regenerates the public imsaif/aiux-skills repo from the pattern registry.
+ * Regenerates the public imsaif/aiux-skills-claude-code repo from the pattern registry.
  *
  * The skills repo is a build artifact: never hand-edit it. This script owns
  * every file in it (38 skill folders + README + LICENSE). Run after any
@@ -53,7 +53,7 @@ A skill is persistent design guidance for your coding agent: install it once and
 All of them:
 
 \`\`\`bash
-npx skills add imsaif/aiux-skills
+npx skills add imsaif/aiux-skills-claude-code
 \`\`\`
 
 Works with Claude Code, Cursor, GitHub Copilot, and every agent the [skills CLI](https://skills.sh) supports. Prefer a hand-picked set? [Browse and save skills on the site](${SITE}/skills?${UTM}) and download them as one pack.

--- a/scripts/skills/sync-skills-repo.ts
+++ b/scripts/skills/sync-skills-repo.ts
@@ -1,5 +1,5 @@
 /**
- * Regenerates the public imsaif/aiux-skills-claude-code repo from the pattern registry.
+ * Regenerates the public imsaif/aiux-skills repo from the pattern registry.
  *
  * The skills repo is a build artifact: never hand-edit it. This script owns
  * every file in it (38 skill folders + README + LICENSE). Run after any
@@ -53,7 +53,7 @@ A skill is persistent design guidance for your coding agent: install it once and
 All of them:
 
 \`\`\`bash
-npx skills add imsaif/aiux-skills-claude-code
+npx skills add imsaif/aiux-skills
 \`\`\`
 
 Works with Claude Code, Cursor, GitHub Copilot, and every agent the [skills CLI](https://skills.sh) supports. Prefer a hand-picked set? [Browse and save skills on the site](${SITE}/skills?${UTM}) and download them as one pack.

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -19,8 +19,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${siteConfig.url}/skills` },
 };
 
-const GENERIC_COMMAND =
-  'mkdir -p .claude/skills/aiux-<slug> && curl -fsSL https://aiuxdesign.guide/skills/aiux-<slug>.md -o .claude/skills/aiux-<slug>/SKILL.md';
+const GENERIC_COMMAND = 'npx skills add imsaif/aiux-skills';
 
 export default function SkillsPage() {
   const categoryNames = categories.map((c) => c.title);
@@ -72,7 +71,7 @@ export default function SkillsPage() {
             <p className="text-lg md:text-xl text-text-secondary">
               A skill is persistent design guidance for your coding agent. Install one and it triggers on
               its own whenever the work matches: no prompting, no reminders. Save the skills you want and
-              download them as one pack, or install any single skill with the command below.
+              download them as one pack, or install all of them with one command.
             </p>
             <pre className="max-w-2xl mx-auto mt-8 overflow-x-auto rounded-input bg-surface-secondary p-snug text-sm text-text-primary text-left">
               {GENERIC_COMMAND}

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${siteConfig.url}/skills` },
 };
 
-const GENERIC_COMMAND = 'npx skills add imsaif/aiux-skills';
+const GENERIC_COMMAND = 'npx skills add imsaif/aiux-skills-claude-code';
 
 export default function SkillsPage() {
   const categoryNames = categories.map((c) => c.title);

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   alternates: { canonical: `${siteConfig.url}/skills` },
 };
 
-const GENERIC_COMMAND = 'npx skills add imsaif/aiux-skills-claude-code';
+const GENERIC_COMMAND = 'npx skills add imsaif/aiux-skills';
 
 export default function SkillsPage() {
   const categoryNames = categories.map((c) => c.title);

--- a/src/data/guides.ts
+++ b/src/data/guides.ts
@@ -8769,6 +8769,21 @@ Audience: Early-stage VCs in the design-tools space.`,
           {
             type: 'heading',
             level: 'h3',
+            content: 'Want everything at once?',
+          },
+          {
+            type: 'text',
+            content: 'The whole library is also published as an open GitHub repo, so one command installs all the skills through the skills CLI. It works with Claude Code, Cursor, GitHub Copilot, and most other coding agents.',
+          },
+          {
+            type: 'code',
+            language: 'bash',
+            label: 'Install every skill',
+            code: 'npx skills add imsaif/aiux-skills',
+          },
+          {
+            type: 'heading',
+            level: 'h3',
             content: 'Just one skill?',
           },
           {

--- a/src/data/guides.ts
+++ b/src/data/guides.ts
@@ -8779,7 +8779,7 @@ Audience: Early-stage VCs in the design-tools space.`,
             type: 'code',
             language: 'bash',
             label: 'Install every skill',
-            code: 'npx skills add imsaif/aiux-skills-claude-code',
+            code: 'npx skills add imsaif/aiux-skills',
           },
           {
             type: 'heading',

--- a/src/data/guides.ts
+++ b/src/data/guides.ts
@@ -8779,7 +8779,7 @@ Audience: Early-stage VCs in the design-tools space.`,
             type: 'code',
             language: 'bash',
             label: 'Install every skill',
-            code: 'npx skills add imsaif/aiux-skills',
+            code: 'npx skills add imsaif/aiux-skills-claude-code',
           },
           {
             type: 'heading',


### PR DESCRIPTION
Executes the free-distribution decision (both advisors converged on Option A). New public repo imsaif/aiux-skills with all 38 skills generated from the pattern registry, UTM-tagged funnel footers in every skill, README as landing page. Sync script: npm run skills:sync. /skills hero command becomes: npx skills add imsaif/aiux-skills. Guide lesson 3 teaches the npx path. Verified end-to-end: the npx install placed all 38 skills (universal layout + Claude Code symlinks). Tests 6/6, tsc clean. 60-day metric: UTM-tagged email captures from repo/skill footers.