### PR TITLE
fix(seo): stop robots.txt blocking our own sitemap.xml

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -10,8 +10,10 @@ export default function robots(): MetadataRoute.Robots {
   const disallow = [
     '/api/',
     '/admin/',
-    '/*.json$',
-    '/*.xml$',
+    // No blanket '/*.xml$' / '/*.json$' here: those patterns matched
+    // /sitemap.xml itself, so Googlebot refused to read the sitemap
+    // ("Sitemap could not be read" in Search Console). Build artifacts are
+    // already covered by /.next/ and /api/.
     '/.next/',
     '/search',
     '/favorites',
@@ -34,8 +36,9 @@ export default function robots(): MetadataRoute.Robots {
         crawlDelay: 0.5,
       },
     ],
-    // Primary sitemap reference
-    sitemap: `${baseUrl}/sitemap.xml`,
+    // Primary sitemap plus the image sitemap, which was previously orphaned —
+    // the route existed at /sitemap-images but nothing pointed Google at it.
+    sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/sitemap-images`],
     host: baseUrl,
   };
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -36,8 +36,11 @@ export default function robots(): MetadataRoute.Robots {
         crawlDelay: 0.5,
       },
     ],
-    // Primary sitemap plus the image sitemap, which was previously orphaned —
-    // the route existed at /sitemap-images but nothing pointed Google at it.
+    // Primary sitemap plus the image sitemap. The image sitemap was reachable
+    // only because it had been submitted by hand in Search Console; declaring
+    // it here survives a property reset and exposes it to other crawlers.
+    // Note it has no .xml extension, which is why it kept being fetched
+    // successfully while /sitemap.xml was blocked by the rule dropped above.
     sitemap: [`${baseUrl}/sitemap.xml`, `${baseUrl}/sitemap-images`],
     host: baseUrl,
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -97,7 +97,29 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: `${baseUrl}/handbook`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/accessibility-checklist-for-ai-designs`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/agentic-ux-checklist`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
     // /search excluded — blocked in robots.txt
+    // /audit excluded — carries robots: { index: false } as a funnel entry point
+    // /prompts/[slug] excluded — one URL per pattern slug, near-duplicate of the
+    //   pattern page; adding 38 thin URLs works against the open
+    //   "discovered - not indexed" backlog (see .claude/rules/seo.md)
     // /aiuxdesign.gist.design removed — static file, not an indexable page
   ];
 


### PR DESCRIPTION
## What

`Disallow: /*.xml$` in `src/app/robots.ts` matched `/sitemap.xml` itself. Google fetches submitted sitemaps subject to robots.txt, so Googlebot has been refusing to read it.

## Evidence

Search Console (Domain property `sc-domain:aiuxdesign.guide`) contains its own control group:

| Sitemap | Last read | Status | Pages |
|---|---|---|---|
| `/sitemap-images` | Aug 13, 2026 | Success | 44 |
| `/sitemap.xml` | **Apr 30, 2026** | **Couldn't fetch** | 138 |

Same host, same server. The one without a `.xml` extension is fetched fine; the one with it has not been read in three and a half months. The live sitemap serves 350 URLs, so roughly 200 URLs of newer content have never appeared in a sitemap Google could read.

## Changes

- Dropped the blanket `/*.xml$` and `/*.json$` disallows. Build artifacts are already covered by `/.next/` and `/api/`; there are no `.json`/`.xml` files under `public/`.
- Declared `/sitemap-images` in robots.txt. It was only reachable because it had been submitted by hand in GSC in May.
- Added three indexable pages missing from the sitemap: `/handbook`, `/accessibility-checklist-for-ai-designs`, `/agentic-ux-checklist`.

## Deliberately left out

- `/audit` carries `robots: { index: false }` as a funnel entry point.
- `/prompts/[slug]` is one URL per pattern slug and near-duplicate of the pattern page. Adding 38 thin URLs works against the open "discovered - not indexed" backlog (see `.claude/rules/seo.md`).

## After merge

1. Confirm the deployed `robots.txt` no longer lists `Disallow: /*.xml$`.
2. GSC → Sitemaps → resubmit `sitemap.xml`.
3. Remove the bogus `https://www.aiuxdesign.guide/patterns` sitemap entry — it is an HTML page submitted as a sitemap ("1 error, 0 discovered").