### PR TITLE
fix(ci): embed the failing measurements in the auto-opened [Perf] issue

### DIFF
--- a/.github/perf-issue-template.md
+++ b/.github/perf-issue-template.md
@@ -1,8 +1,10 @@
 The nightly Lighthouse CI run failed against the production budget defined in `budget.json`.
 
-**Run**: see the "Performance" workflow in the [Actions tab](../../actions/workflows/perf.yml) for the failing URL(s) and the specific assertion that breached.
+**The failing URLs, budgets and measured values are recorded above**, at run time, by `scripts/ci/perf-issue-body.mjs`. They stay readable for the life of this issue. Everything below is the standing investigation checklist.
 
-**LHCI report**: linked in the workflow run summary (uploaded to LHCI temporary public storage — link expires after ~7 days, so click through soon).
+**Run**: see the "Performance" workflow in the [Actions tab](../../actions/workflows/perf.yml). Note the log expires after ~90 days — if this issue is older than that, the embedded numbers above are the only record.
+
+**LHCI report**: linked above when available (uploaded to LHCI temporary public storage — the link expires after ~7 days, so click through soon).
 
 ## Investigate
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,12 +37,26 @@ jobs:
           configPath: './lighthouserc.json'
           uploadArtifacts: true
           temporaryPublicStorage: true
+      # Embed the actual failing assertions in the issue body. The issue used to
+      # be the template verbatim — a checklist and a link to this run, with no
+      # measurement — so once the Actions log expired (~90 days) and the LHCI
+      # report links died (~7 days), the issue became unfalsifiable. #26 and #28
+      # (Apr 2026) had to be closed in Aug 2026 as "cause unrecoverable" for
+      # exactly that reason. Never let this step fail the notification: on any
+      # problem it falls back to the bare template.
+      - name: Build issue body with measurements
+        if: failure() && github.event_name == 'schedule'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node scripts/ci/perf-issue-body.mjs ./perf-issue-body.md \
+            || cp ./.github/perf-issue-template.md ./perf-issue-body.md
       - name: Open issue on regression
         if: failure() && github.event_name == 'schedule'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "[Perf] LHCI regression detected — run ${{ github.run_id }}"
-          content-filepath: ./.github/perf-issue-template.md
+          content-filepath: ./perf-issue-body.md
           labels: |
             performance
             automated

--- a/scripts/ci/perf-issue-body.mjs
+++ b/scripts/ci/perf-issue-body.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Build the body for the auto-opened [Perf] issue, with the actual failing
+ * assertions embedded.
+ *
+ * Why this exists. The issue used to be `.github/perf-issue-template.md`
+ * verbatim: a checklist plus a pointer to the Actions run, and NO measurement.
+ * GitHub expires workflow logs at ~90 days and the LHCI report links die after
+ * ~7, so once those lapse the issue is unfalsifiable — you cannot tell what
+ * breached, by how much, or whether it still matters. Issues #26 and #28
+ * (Apr 2026) had to be closed in Aug 2026 as "stale, cause unrecoverable"
+ * purely because of this; the only thing that made them safe to close was 139
+ * unrelated green runs, not anything the issues themselves recorded.
+ *
+ * So: read `.lighthouseci/assertion-results.json` (written by `lhci assert`)
+ * and put the numbers IN the issue, where they live as long as the issue does.
+ *
+ * Usage: node scripts/ci/perf-issue-body.mjs <outfile>
+ *
+ * FAIL-SAFE BY DESIGN: any problem reading or parsing the results still emits
+ * the template, so a bad shape degrades the issue's detail rather than losing
+ * the notification entirely. Never let this throw.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+
+const OUT = process.argv[2] || './perf-issue-body.md';
+const RESULTS = '.lighthouseci/assertion-results.json';
+const LINKS = '.lighthouseci/links.json';
+const TEMPLATE = '.github/perf-issue-template.md';
+
+const runUrl = process.env.RUN_URL || '';
+const sha = process.env.GITHUB_SHA || '';
+
+function readJson(path) {
+  try {
+    return existsSync(path) ? JSON.parse(readFileSync(path, 'utf8')) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** resource-summary budgets report bytes; timings report ms. Render both readably. */
+function fmt(value, auditId, auditProperty) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return String(value ?? '—');
+  const isSize = auditId === 'resource-summary' || /size|bytes/i.test(auditProperty || '');
+  if (isSize) return `${Math.round(value / 1024)} KB`;
+  const isTiming = /timing|paint|interactive|blocking|cumulative/i.test(`${auditId} ${auditProperty}`);
+  if (isTiming && value > 10) return `${Math.round(value)} ms`;
+  return String(value);
+}
+
+function buildSummary() {
+  const results = readJson(RESULTS);
+  if (!Array.isArray(results) || results.length === 0) return null;
+
+  const failed = results.filter((r) => r && r.passed === false);
+  if (failed.length === 0) return null;
+
+  const links = readJson(LINKS) || {};
+  const byUrl = new Map();
+  for (const r of failed) {
+    const url = r.url || '(unknown URL)';
+    if (!byUrl.has(url)) byUrl.set(url, []);
+    byUrl.get(url).push(r);
+  }
+
+  const lines = [];
+  lines.push('## What breached');
+  lines.push('');
+  lines.push(
+    `**${failed.length} failing assertion${failed.length === 1 ? '' : 's'} across ${byUrl.size} URL${byUrl.size === 1 ? '' : 's'}.** ` +
+      'Recorded here at run time — the Actions log expires at ~90 days and the LHCI report links at ~7, so these numbers are the durable record.'
+  );
+  lines.push('');
+
+  for (const [url, items] of byUrl) {
+    lines.push(`### \`${url}\``);
+    lines.push('');
+    lines.push('| Assertion | Operator | Budget | Measured | Over by |');
+    lines.push('|---|---|---|---|---|');
+    for (const r of items) {
+      const audit = [r.auditId, r.auditProperty].filter(Boolean).join('.');
+      const over =
+        typeof r.actual === 'number' && typeof r.expected === 'number'
+          ? fmt(r.actual - r.expected, r.auditId, r.auditProperty)
+          : '—';
+      lines.push(
+        `| \`${audit || r.name || '?'}\` | \`${r.operator ?? '?'}\` | ${fmt(r.expected, r.auditId, r.auditProperty)} | **${fmt(r.actual, r.auditId, r.auditProperty)}** | ${over} |`
+      );
+    }
+    const report = links[url];
+    if (report) {
+      lines.push('');
+      lines.push(`[LHCI report](${report}) *(expires ~7 days)*`);
+    }
+    lines.push('');
+  }
+
+  lines.push('> **Before treating this as a regression, check the Performance score on the affected pages.**');
+  lines.push('> A small overage on a page still scoring 90+ means the budget is the wrong instrument, not the page —');
+  lines.push('> see the Aug 2026 row in `.claude/rules/performance.md`, where a 1.3% overage on pages scoring 94–96');
+  lines.push('> reddened CI for a week. Do not trim bytes to fit a budget that was set with no headroom.');
+  lines.push('');
+  if (runUrl) lines.push(`**Run:** ${runUrl}`);
+  if (sha) lines.push(`**Commit:** \`${sha.slice(0, 8)}\``);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+
+let body = '';
+try {
+  body = buildSummary() || '';
+} catch (err) {
+  body = `> Could not parse \`${RESULTS}\` (${err instanceof Error ? err.message : String(err)}). Falling back to the checklist below.\n\n---\n\n`;
+}
+
+let template = '';
+try {
+  template = existsSync(TEMPLATE) ? readFileSync(TEMPLATE, 'utf8') : '';
+} catch {
+  template = '';
+}
+
+writeFileSync(OUT, `${body}${template}` || 'Lighthouse CI failed. See the Actions run.\n');
+console.log(`[perf-issue-body] wrote ${OUT} (${body ? 'with' : 'WITHOUT'} embedded measurements)`);


### PR DESCRIPTION
## The problem

The auto-opened `[Perf]` issue was `.github/perf-issue-template.md` **verbatim** — an investigation checklist and a link to the Actions run, with **no measurement**. So the issue is only diagnosable while its external evidence lives:

- GitHub drops workflow logs at **~90 days**
- LHCI report links die after **~7 days**

After that you can't tell what breached, by how much, or whether it still matters.

## This already cost real work

Closing out today's backlog, **#26 and #28** (Apr 2026) had to be closed as *"stale, cause unrecoverable"*:

```
$ gh run view 24550351252 --log-failed
failed to get run log: HTTP 410
```

The only thing that made them safe to close was **139 unrelated green runs afterwards** — nothing the issues themselves recorded. The seven from August (#61–#72) were diagnosable purely because their runs were recent.

## The change

A new step reads `.lighthouseci/assertion-results.json` (written by `lhci assert`) and writes the numbers into the issue body:

```markdown
### `https://www.aiuxdesign.guide/patterns/conversational-ui`

| Assertion | Operator | Budget | Measured | Over by |
|---|---|---|---|---|
| `resource-summary.script.size` | `<=` | 600 KB | **608 KB** | 8 KB |
```

Plus the LHCI report link from `links.json`, the run URL, and the commit SHA. Bytes render as KB and timings as ms, so `622592` reads as `608 KB` rather than raw bytes.

The body also carries forward the lesson from today's incident:

> **Before treating this as a regression, check the Performance score on the affected pages.** A small overage on a page still scoring 90+ means the budget is the wrong instrument, not the page.

That is exactly the mistake this repo just spent a week red on.

## Fail-safe by design

The script **never throws**. Missing file, malformed JSON, or an unexpected shape all degrade to the bare template rather than losing the notification — and the workflow step has a `|| cp` fallback on top of that. A parsing bug must never cost you the alert.

## Verification

Three cases, run locally against a fixture built from the real 08-17 failure:

| Case | Result |
|---|---|
| Valid results | Embeds correctly — 608 KB vs 600 KB, +8 KB; passing assertion excluded; timings render as ms |
| Missing `assertion-results.json` | Falls back to template, exit 0 |
| Malformed JSON | Falls back to template, exit 0 |

YAML parses; `content-filepath` correctly repointed.

Note CI can't exercise the new step on this PR — it only runs `if: failure() && github.event_name == 'schedule'`, so it first fires on a genuinely failing nightly. That's why it was verified against a fixture and made unable to throw.
