### PR TITLE
feat(newsletter): add four first-party product feeds

### DIFF
--- a/src/app/admin/newsletter/admin-newsletter-client.tsx
+++ b/src/app/admin/newsletter/admin-newsletter-client.tsx
@@ -549,16 +549,8 @@ export default function AdminNewsletterClient({
                           status-coloured text fails contrast as body copy, and the
                           "Flagged" label carries the meaning so it never rests on
                           colour alone. */}
-                      {/* 2026-08-18: `no_product_news` was renamed
-                          `product_news_floor` when the floor went from a flat 1 to
-                          "at least half, min 2". Both prefixes stay suppressed — the
-                          rule is still FEED-aware (a source-tier proxy), not
-                          story-aware, so the condition named above for re-evaluating
-                          the banner is still not met. Revisit only if the counter
-                          starts reading the story itself. */}
                       {qa.selectionRuleViolation &&
-                        !qa.selectionRuleViolation.startsWith('no_product_news') &&
-                        !qa.selectionRuleViolation.startsWith('product_news_floor') && (
+                        !qa.selectionRuleViolation.startsWith('no_product_news') && (
                         <div className="mb-3 p-2.5 rounded-md bg-status-warning/10 border border-status-warning/40 text-text-primary text-xs md:text-sm">
                           <span className="font-semibold">⚠ Flagged &mdash; selection rule broken:</span>{' '}
                           <span className="font-mono">{qa.selectionRuleViolation}</span>

--- a/src/app/admin/newsletter/admin-newsletter-client.tsx
+++ b/src/app/admin/newsletter/admin-newsletter-client.tsx
@@ -549,8 +549,16 @@ export default function AdminNewsletterClient({
                           status-coloured text fails contrast as body copy, and the
                           "Flagged" label carries the meaning so it never rests on
                           colour alone. */}
+                      {/* 2026-08-18: `no_product_news` was renamed
+                          `product_news_floor` when the floor went from a flat 1 to
+                          "at least half, min 2". Both prefixes stay suppressed — the
+                          rule is still FEED-aware (a source-tier proxy), not
+                          story-aware, so the condition named above for re-evaluating
+                          the banner is still not met. Revisit only if the counter
+                          starts reading the story itself. */}
                       {qa.selectionRuleViolation &&
-                        !qa.selectionRuleViolation.startsWith('no_product_news') && (
+                        !qa.selectionRuleViolation.startsWith('no_product_news') &&
+                        !qa.selectionRuleViolation.startsWith('product_news_floor') && (
                         <div className="mb-3 p-2.5 rounded-md bg-status-warning/10 border border-status-warning/40 text-text-primary text-xs md:text-sm">
                           <span className="font-semibold">⚠ Flagged &mdash; selection rule broken:</span>{' '}
                           <span className="font-mono">{qa.selectionRuleViolation}</span>

--- a/src/app/api/cron/generate-newsletter/route.ts
+++ b/src/app/api/cron/generate-newsletter/route.ts
@@ -1634,9 +1634,8 @@ YOUR TASK:
    - Prefer items from design-research publications (Nielsen Norman, Smashing Magazine, A List Apart, TLDR Design) and design tools (Figma, Framer) over dev platforms (Vercel, GitHub, Supabase, Replit) when both are present at similar relevance scores.
 
    PRODUCT-NEWS FLOOR (strict — overrides relevance scoring):
-   - AT LEAST HALF of your selected items MUST be concrete product news from an AI lab, design tool, or dev platform (e.g., OpenAI, Anthropic/Claude, Google AI, Microsoft AI, Perplexity, Cursor, Notion, Linear, Windsurf, Figma, Framer, Vercel, GitHub, Replit). Never fewer than 2. So: 4 items → at least 2 product news, 5 items → at least 3, 6 items → at least 3. A "concrete product news" item announces a launch, feature, version, or dated change — not an opinion piece or framework essay about that space.
-   - Count them before you answer. Frameworks, "how we think about X" posts, design-system craft essays and drift/debt guides are NOT product news, however well-argued — they are the other half of the issue, not this half.
-   - If the pool genuinely contains fewer than 2 such items, return fewer total items rather than padding with essays. A 2-item issue with 2 product launches beats a 4-item issue with 1.
+   - At least 1 of your selected items MUST be concrete product news from an AI lab or design tool (e.g., OpenAI, Anthropic/Claude, Google AI, Microsoft AI, Perplexity, Cursor, Notion, Linear, Windsurf, Figma, Framer). A "concrete product news" item announces a launch, feature, version, or dated change — not an opinion piece about that company.
+   - If the pool genuinely contains zero such items, return fewer total items rather than padding with opinion/articles. A 3-item issue with 1 product launch beats a 4-item all-opinion issue.
 
    DIVERSITY RULES (strict — these override relevance scoring):
    - Pick items from at least 3 DIFFERENT companies/products. A newsletter where every item is from one company is not useful.
@@ -2174,24 +2173,6 @@ interface NewsletterQATelemetry {
 // product field instead of the source field. Mirrors the prompt's value of 2.
 const MAX_ITEMS_PER_COMPANY = 2;
 
-// Product-news floor, expressed as a fraction of the issue rather than a flat
-// count. The daily prompt asks for 4-6 items, so the old flat `>= 1` meant a
-// 6-story issue could legally carry 5 essays. Raised 2026-08-18 after the Aug-18
-// draft shipped 4 stories with exactly 1 product item (Adobe Workfront) while
-// the pool held Cursor's Origin launch, Replit's governance tools and the
-// Stripe/OpenRouter deal — the floor passed, so nothing flagged it.
-//
-// "At least half, minimum 2" is also how the opinion cap is enforced now. The
-// obvious alternative — widening `isOpinionUrl` so essays from Sparkbox-style
-// agency blogs and curated Substacks count as opinion — is NOT safe: that
-// predicate is also the pool pre-filter (see the `opinionFiltered` call), so
-// widening it would strip those sources before scoring and structurally kill
-// them, the same failure the curator tier hit with latent.space. Bounding
-// product news from below bounds essays from above without touching the pool.
-function requiredProductNews(itemCount: number): number {
-  return Math.max(2, Math.ceil(itemCount / 2));
-}
-
 // Hosts we DELIBERATELY subscribe to (derived from RSS_SOURCES so it never drifts
 // out of sync). Used by isOpinionUrl to exempt our curated practitioner Substacks
 // (Jakob Nielsen, Julie Zhuo, Emily Campbell, Design Systems Collective, etc.) from
@@ -2273,7 +2254,7 @@ You selected more than ${MAX_ITEMS_PER_COMPANY} stories about the same company o
 
 CRITICAL RETRY — your previous selection violated the rules: ${violation}.
 
-Your selection did not carry enough concrete product news. At least HALF of your items (never fewer than 2) must be product news. Add items from this list of concrete product-news sources that were in the pool, dropping your weakest framework/essay picks to make room. Pick the most designer-relevant ones:
+You MUST include AT LEAST ONE item from this list of concrete product-news sources that were in the pool. Pick the most designer-relevant one:
 
 ${lines}
 
@@ -2355,21 +2336,17 @@ function buildQABlock(
   // Hard selection rules for daily issues. Violations route to auto-quiet so
   // we don't ship opinion-heavy filler when the pool can't support real news.
   // Two violation types:
-  //   1) productNewsCount < requiredProductNews(n) → too little concrete news.
+  //   1) productNewsCount < 1 → no concrete launch in the issue at all.
   //   2) opinionCount > 0 → any opinion item disqualifies the issue.
-  // Pool-aware escape hatch: if the pool couldn't supply the required count,
-  // rule (1) doesn't fire — there's nothing better Claude could have picked.
+  // Pool-aware escape hatch: if the pool genuinely contained zero product-news
+  // items, rule (1) doesn't fire — there's nothing better Claude could have
+  // picked, and shipping 4 design-pub items is acceptable.
   //
   // MUST use the same predicate as the counter above. When the numerator and
   // this hatch disagree, a day whose pool carries product news ONLY from the
   // tier one side recognises slips through un-guarded.
-  const requiredProduct = requiredProductNews(selectedItems.length);
   const poolProductNews = pool.filter(isProductNewsItem);
-  // Hatch must use the SAME threshold as the guard below. If the guard demands 2
-  // and the hatch only asks "> 0", a day whose pool holds exactly 1 product item
-  // flags a violation it can never satisfy and routes to auto-quiet — a silent
-  // daily outage rather than an honest short issue.
-  const poolHadProductNews = poolProductNews.length >= requiredProduct;
+  const poolHadProductNews = poolProductNews.length > 0;
   // Company-cap violation: any single product label appears more than twice.
   let companyCapViolation: string | null = null;
   for (const [key, count] of Object.entries(productCounts)) {
@@ -2380,8 +2357,8 @@ function buildQABlock(
   }
 
   let selectionRuleViolation: string | null = null;
-  if (productNewsCount < requiredProduct && poolHadProductNews) {
-    selectionRuleViolation = `product_news_floor (need ${requiredProduct} of ${selectedItems.length}, pool had ${poolProductNews.length}, Claude picked ${productNewsCount})`;
+  if (productNewsCount < 1 && poolHadProductNews) {
+    selectionRuleViolation = `no_product_news (pool had ${poolProductNews.length} product-news items but Claude picked 0)`;
   } else if (opinionCount > 0) {
     selectionRuleViolation = `opinion_present (${opinionCount} opinion items, max 0)`;
   } else if (companyCapViolation) {

--- a/src/app/api/cron/generate-newsletter/route.ts
+++ b/src/app/api/cron/generate-newsletter/route.ts
@@ -1613,8 +1613,9 @@ YOUR TASK:
    - Prefer items from design-research publications (Nielsen Norman, Smashing Magazine, A List Apart, TLDR Design) and design tools (Figma, Framer) over dev platforms (Vercel, GitHub, Supabase, Replit) when both are present at similar relevance scores.
 
    PRODUCT-NEWS FLOOR (strict — overrides relevance scoring):
-   - At least 1 of your selected items MUST be concrete product news from an AI lab or design tool (e.g., OpenAI, Anthropic/Claude, Google AI, Microsoft AI, Perplexity, Cursor, Notion, Linear, Windsurf, Figma, Framer). A "concrete product news" item announces a launch, feature, version, or dated change — not an opinion piece about that company.
-   - If the pool genuinely contains zero such items, return fewer total items rather than padding with opinion/articles. A 3-item issue with 1 product launch beats a 4-item all-opinion issue.
+   - AT LEAST HALF of your selected items MUST be concrete product news from an AI lab, design tool, or dev platform (e.g., OpenAI, Anthropic/Claude, Google AI, Microsoft AI, Perplexity, Cursor, Notion, Linear, Windsurf, Figma, Framer, Vercel, GitHub, Replit). Never fewer than 2. So: 4 items → at least 2 product news, 5 items → at least 3, 6 items → at least 3. A "concrete product news" item announces a launch, feature, version, or dated change — not an opinion piece or framework essay about that space.
+   - Count them before you answer. Frameworks, "how we think about X" posts, design-system craft essays and drift/debt guides are NOT product news, however well-argued — they are the other half of the issue, not this half.
+   - If the pool genuinely contains fewer than 2 such items, return fewer total items rather than padding with essays. A 2-item issue with 2 product launches beats a 4-item issue with 1.
 
    DIVERSITY RULES (strict — these override relevance scoring):
    - Pick items from at least 3 DIFFERENT companies/products. A newsletter where every item is from one company is not useful.
@@ -2152,6 +2153,24 @@ interface NewsletterQATelemetry {
 // product field instead of the source field. Mirrors the prompt's value of 2.
 const MAX_ITEMS_PER_COMPANY = 2;
 
+// Product-news floor, expressed as a fraction of the issue rather than a flat
+// count. The daily prompt asks for 4-6 items, so the old flat `>= 1` meant a
+// 6-story issue could legally carry 5 essays. Raised 2026-08-18 after the Aug-18
+// draft shipped 4 stories with exactly 1 product item (Adobe Workfront) while
+// the pool held Cursor's Origin launch, Replit's governance tools and the
+// Stripe/OpenRouter deal — the floor passed, so nothing flagged it.
+//
+// "At least half, minimum 2" is also how the opinion cap is enforced now. The
+// obvious alternative — widening `isOpinionUrl` so essays from Sparkbox-style
+// agency blogs and curated Substacks count as opinion — is NOT safe: that
+// predicate is also the pool pre-filter (see the `opinionFiltered` call), so
+// widening it would strip those sources before scoring and structurally kill
+// them, the same failure the curator tier hit with latent.space. Bounding
+// product news from below bounds essays from above without touching the pool.
+function requiredProductNews(itemCount: number): number {
+  return Math.max(2, Math.ceil(itemCount / 2));
+}
+
 // Hosts we DELIBERATELY subscribe to (derived from RSS_SOURCES so it never drifts
 // out of sync). Used by isOpinionUrl to exempt our curated practitioner Substacks
 // (Jakob Nielsen, Julie Zhuo, Emily Campbell, Design Systems Collective, etc.) from
@@ -2233,7 +2252,7 @@ You selected more than ${MAX_ITEMS_PER_COMPANY} stories about the same company o
 
 CRITICAL RETRY — your previous selection violated the rules: ${violation}.
 
-You MUST include AT LEAST ONE item from this list of concrete product-news sources that were in the pool. Pick the most designer-relevant one:
+Your selection did not carry enough concrete product news. At least HALF of your items (never fewer than 2) must be product news. Add items from this list of concrete product-news sources that were in the pool, dropping your weakest framework/essay picks to make room. Pick the most designer-relevant ones:
 
 ${lines}
 
@@ -2315,17 +2334,21 @@ function buildQABlock(
   // Hard selection rules for daily issues. Violations route to auto-quiet so
   // we don't ship opinion-heavy filler when the pool can't support real news.
   // Two violation types:
-  //   1) productNewsCount < 1 → no concrete launch in the issue at all.
+  //   1) productNewsCount < requiredProductNews(n) → too little concrete news.
   //   2) opinionCount > 0 → any opinion item disqualifies the issue.
-  // Pool-aware escape hatch: if the pool genuinely contained zero product-news
-  // items, rule (1) doesn't fire — there's nothing better Claude could have
-  // picked, and shipping 4 design-pub items is acceptable.
+  // Pool-aware escape hatch: if the pool couldn't supply the required count,
+  // rule (1) doesn't fire — there's nothing better Claude could have picked.
   //
   // MUST use the same predicate as the counter above. When the numerator and
   // this hatch disagree, a day whose pool carries product news ONLY from the
   // tier one side recognises slips through un-guarded.
+  const requiredProduct = requiredProductNews(selectedItems.length);
   const poolProductNews = pool.filter(isProductNewsItem);
-  const poolHadProductNews = poolProductNews.length > 0;
+  // Hatch must use the SAME threshold as the guard below. If the guard demands 2
+  // and the hatch only asks "> 0", a day whose pool holds exactly 1 product item
+  // flags a violation it can never satisfy and routes to auto-quiet — a silent
+  // daily outage rather than an honest short issue.
+  const poolHadProductNews = poolProductNews.length >= requiredProduct;
   // Company-cap violation: any single product label appears more than twice.
   let companyCapViolation: string | null = null;
   for (const [key, count] of Object.entries(productCounts)) {
@@ -2336,8 +2359,8 @@ function buildQABlock(
   }
 
   let selectionRuleViolation: string | null = null;
-  if (productNewsCount < 1 && poolHadProductNews) {
-    selectionRuleViolation = `no_product_news (pool had ${poolProductNews.length} product-news items but Claude picked 0)`;
+  if (productNewsCount < requiredProduct && poolHadProductNews) {
+    selectionRuleViolation = `product_news_floor (need ${requiredProduct} of ${selectedItems.length}, pool had ${poolProductNews.length}, Claude picked ${productNewsCount})`;
   } else if (opinionCount > 0) {
     selectionRuleViolation = `opinion_present (${opinionCount} opinion items, max 0)`;
   } else if (companyCapViolation) {

--- a/src/app/api/cron/generate-newsletter/route.ts
+++ b/src/app/api/cron/generate-newsletter/route.ts
@@ -96,6 +96,13 @@ const RSS_SOURCES: RssSource[] = [
   // (verified Apr 20 2026: /blog/rss.xml, /blog/feed/, /blog/atom.xml all 404).
   // Revisit if they ship one or via an aggregator.
   { name: 'Figma', url: 'https://www.figma.com/blog/feed/atom.xml', color: '#f24e1e', tier: 'design-tool' },
+  // Added 2026-08-18. The Aug-18 "no AI product news" complaint traced to this:
+  // for the tools designers actually use, the CHANGELOG is the designer-relevant
+  // feed and the BLOG is the corporate one — and we were subscribed only to blogs.
+  // Verified live the same day: 444 entries, near-daily, and squarely on-topic
+  // (Figma agent skills, Figma MCP/Weave, responsive text wrap). This is the feed
+  // the Aug-18 pool most obviously lacked.
+  { name: 'Figma Release Notes', url: 'https://www.figma.com/release-notes/feed/atom.xml', color: '#f24e1e', tier: 'design-tool' },
   // First-party design-tool blogs with real RSS (added Jul 15 2026 to thicken this tier — was Figma-only)
   { name: 'UXPin', url: 'https://www.uxpin.com/studio/feed/', color: '#00c9a7', tier: 'design-tool' }, // AI-native design tool, near-daily
   { name: 'Dovetail', url: 'https://dovetail.com/blog/rss.xml', color: '#6b4eff', tier: 'design-tool' }, // AI UX-research platform
@@ -116,6 +123,14 @@ const RSS_SOURCES: RssSource[] = [
 
   // AI labs (Google News searches for AI products)
   { name: 'Cursor', url: 'https://news.google.com/rss/search?q=Cursor+AI+editor+OR+Cursor+code+editor&hl=en-US&gl=US&ceid=US:en', color: '#7c3aed', tier: 'ai-lab' },
+  // First-party changelogs, added 2026-08-18 alongside Figma Release Notes. Both
+  // products were previously reachable ONLY via the Google News searches above,
+  // which is why Cursor's Origin launch arrived on Aug-17 as a VentureBeat piece
+  // framed around a GitHub outage rather than as the release itself. The Google
+  // News entries stay — they catch acquisitions and third-party coverage a
+  // changelog never mentions — and MAX_ITEMS_PER_COMPANY caps the pair at 2.
+  { name: 'Cursor Changelog', url: 'https://cursor.com/changelog/rss.xml', color: '#7c3aed', tier: 'ai-lab' },
+  { name: 'Notion Releases', url: 'https://www.notion.so/releases/rss.xml', color: '#000000', tier: 'ai-lab' }, // interface-level changes (model picker, Custom Agents, high-contrast mode), not coverage of them
   { name: 'Notion', url: 'https://news.google.com/rss/search?q=Notion+AI+OR+Notion+app+update&hl=en-US&gl=US&ceid=US:en', color: '#000000', tier: 'ai-lab' },
   { name: 'Linear', url: 'https://news.google.com/rss/search?q=Linear+app+OR+Linear+project+management&hl=en-US&gl=US&ceid=US:en', color: '#5e6ad2', tier: 'ai-lab' },
   { name: 'Perplexity', url: 'https://news.google.com/rss/search?q=Perplexity+AI&hl=en-US&gl=US&ceid=US:en', color: '#20808d', tier: 'ai-lab' },
@@ -164,6 +179,12 @@ const RSS_SOURCES: RssSource[] = [
   { name: 'Vercel', url: 'https://vercel.com/atom', color: '#000000', tier: 'dev-platform' },
   { name: 'GitHub', url: 'https://github.blog/feed/', color: '#333333', tier: 'dev-platform' },
   { name: 'Supabase', url: 'https://supabase.com/rss.xml', color: '#3ecf8e', tier: 'dev-platform' }, // /blog/rss.xml 404 (Jul 15 2026)
+  // Added 2026-08-18. AI app builder designers actually touch; near-daily, and the
+  // writing is design-shaped ("The model picker is a dead end"). Deliberately
+  // `dev-platform`, NOT `design-tool`: dev-platform product-news status is gated by
+  // the infra test, so a funding round ("we raised $400M Series C") can't march
+  // into the issue as a product launch the way a design-tool item would.
+  { name: 'Lovable', url: 'https://lovable.dev/blog/rss.xml', color: '#f97316', tier: 'dev-platform' },
 
   // Tech news (keyword-only scoring — no source baseline)
   { name: 'The Verge', url: 'https://www.theverge.com/rss/ai-artificial-intelligence/index.xml', color: '#e5127d', tier: 'tech-news' }, // old path 404 (Jul 15 2026)
@@ -179,7 +200,7 @@ const RSS_SOURCES: RssSource[] = [
 // (the previous lite slice was Vercel/GitHub/Supabase-heavy).
 const RSS_SOURCES_LITE: RssSource[] = RSS_SOURCES.filter((s) =>
   ['Nielsen Norman Group', 'Smashing Magazine', 'UX Collective', 'A List Apart',
-   'TLDR Design', 'Figma', 'OpenAI', 'Google AI'].includes(s.name)
+   'TLDR Design', 'Figma', 'Figma Release Notes', 'OpenAI', 'Google AI'].includes(s.name)
 );
 
 // Scrape Anthropic news (no RSS feed available). Anthropic posts first-party


### PR DESCRIPTION
## Why

The Aug-18 daily read as all design opinion with no AI product news. Investigating the pool showed the cause was **sourcing, not selection**.

The ai-lab / dev-platform items available that day were Vercel gateway pricing, Replit pen-testing, Hugging Face GPU management, and a Google/football sponsorship. The selection model was right to drop them — none belong in a designer's newsletter.

The pattern: for the tools designers actually use, the **changelog** is the designer-relevant feed and the **blog** is the corporate one. Every product source here was a blog or a Google News search.

## What

Four feeds, each verified live on 2026-08-18 via `rss-parser` using the cron's own User-Agent:

| Feed | Entries | Tier | Note |
|---|---|---|---|
| Figma Release Notes | 444, near-daily | `design-tool` | Figma agent skills, MCP/Weave, text wrap. Most likely to have changed the Aug-18 issue on its own. |
| Cursor Changelog | 50 | `ai-lab` | Carries "Origin Code Hosting" directly; via Google News the same launch arrived as a VentureBeat story about a GitHub outage. |
| Notion Releases | 148 | `ai-lab` | Interface changes, not coverage of them. |
| Lovable | 148, near-daily | `dev-platform` | Deliberately **not** `design-tool` — dev-platform product-news status is gated by the infra test, so funding announcements can't enter as product launches. |

Figma Release Notes also joins `RSS_SOURCES_LITE` so a degraded run still keeps a real product item.

Existing Google News entries for Cursor and Notion stay — they catch acquisitions and third-party coverage a changelog never mentions, and `MAX_ITEMS_PER_COMPANY` caps the pair at 2.

## Rejected (no working feed)

Framer, Linear, Anthropic, Perplexity, Canva, ElevenLabs, Adobe, Google Design, Material Design. Raycast's feed exists but is malformed. Sketch's is alive but last published 2026-02-20.

## Also in this branch

A product-news floor change (`max(2, ceil(n/2))`) was committed and then **reverted** in `e1e2310`. Reading the pool showed the floor was the wrong lever — forcing a quota would only push Vercel gateway discounts into issues. Three local reruns confirmed it: the guard fired correctly every time, but the enforcement retry, even with a 187s budget and the eligible URLs named explicitly, still returned 0 of 15 available product-news items. The commit and its reasoning are kept in history as a documented dead end.

## Watch after merge

Figma now has two feeds. Each is capped at 1 pool item per day, so Figma can reach the `MAX_ITEMS_PER_COMPANY` limit of 2 in one issue — the ceiling the Jun 2026 three-Figma complaint set, but sitting at it rather than below it.

## Verification

Feed liveness verified directly. No generation run against these feeds yet — the first real test is the first daily cron after this deploys.
