### PR TITLE
Add paid 1:1 call offer to the Claude learning paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,11 @@ ADMIN_APPROVE_SECRET=generate-with-openssl-rand-hex-32
 # Site Configuration
 NEXT_PUBLIC_SITE_URL=https://your-domain.com
 NEXT_PUBLIC_MOCK_ANALYSIS=false
+
+# Paid 1:1 call offer (/call). Both are plain URLs, no secrets.
+# Every call-offer surface renders nothing while DODO_CALL_LINK is unset, so the
+# feature is invisible until these are filled in.
+# The Dodo Static Payment Link MUST have its redirect_url set to
+# <site>/call/booked, or a paying customer never reaches the booking calendar.
+NEXT_PUBLIC_DODO_CALL_LINK=
+NEXT_PUBLIC_CAL_BOOKING_URL=

--- a/src/app/call/booked/page.tsx
+++ b/src/app/call/booked/page.tsx
@@ -1,0 +1,56 @@
+import { Metadata } from 'next';
+import Navbar from '@/components/layout/Navbar';
+import Footer from '@/components/layout/Footer';
+import BookingEmbed from '@/components/call/BookingEmbed';
+import { CALL_OFFER, CAL_BOOKING_URL } from '@/lib/call-offer';
+
+// The Dodo Static Payment Link's redirect_url points here. Reached only after
+// paying, so it is deliberately kept out of the index and out of the sitemap.
+export const metadata: Metadata = {
+  title: 'Pick a time for your session',
+  robots: { index: false, follow: false },
+};
+
+export default function CallBookedPage() {
+  return (
+    <main className="min-h-screen bg-background-primary text-text-primary">
+      <Navbar />
+
+      <section className="pt-12 md:pt-16 pb-16 md:pb-24">
+        <div className="max-w-4xl mx-auto px-6">
+          <div className="text-center mb-10">
+            <h1 className="text-3xl md:text-4xl font-bold mb-4">
+              Payment received — now pick your time
+            </h1>
+            <p className="text-text-secondary max-w-2xl mx-auto">
+              Choose any slot below and your {CALL_OFFER.durationLabel} session is
+              confirmed. Send your repo, Figma file, or a note about where you are
+              stuck when you book, so we start on the problem rather than the setup.
+            </p>
+          </div>
+
+          <BookingEmbed />
+
+          {/* If someone closes this tab before booking, the receipt email is the
+              only way back. Paste the booking link into the Dodo receipt template. */}
+          {CAL_BOOKING_URL && (
+            <p className="mt-6 text-center text-sm text-text-secondary">
+              Calendar not loading?{' '}
+              <a
+                href={CAL_BOOKING_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent-primary hover:text-accent-hover font-medium underline underline-offset-2"
+              >
+                Open it in a new tab
+              </a>
+              .
+            </p>
+          )}
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/call/booked/page.tsx
+++ b/src/app/call/booked/page.tsx
@@ -20,7 +20,7 @@ export default function CallBookedPage() {
         <div className="max-w-4xl mx-auto px-6">
           <div className="text-center mb-10">
             <h1 className="text-3xl md:text-4xl font-bold mb-4">
-              Payment received — now pick your time
+              Payment received. Now pick your time.
             </h1>
             <p className="text-text-secondary max-w-2xl mx-auto">
               Choose any slot below and your {CALL_OFFER.durationLabel} session is

--- a/src/app/call/page.tsx
+++ b/src/app/call/page.tsx
@@ -31,7 +31,7 @@ const WHAT_HAPPENS = [
   },
   {
     title: 'You keep whatever we make',
-    body: 'Prompts, config, code, or a plan — written down in the call, not sent afterwards.',
+    body: 'Prompts, config, code, or a plan, written down during the call rather than sent afterwards.',
   },
 ];
 

--- a/src/app/call/page.tsx
+++ b/src/app/call/page.tsx
@@ -1,0 +1,103 @@
+import { Metadata } from 'next';
+import Navbar from '@/components/layout/Navbar';
+import Footer from '@/components/layout/Footer';
+import CallCheckout from '@/components/call/CallCheckout';
+import { CALL_OFFER } from '@/lib/call-offer';
+
+export const metadata: Metadata = {
+  title: `Book a session | ${CALL_OFFER.priceLabel} for ${CALL_OFFER.durationLabel}`,
+  description: `A ${CALL_OFFER.durationLabel} one-to-one working session on your own Claude Code or Claude Design project. Bring your codebase and your actual blockers.`,
+  openGraph: {
+    title: `Book a session | ${CALL_OFFER.priceLabel} for ${CALL_OFFER.durationLabel}`,
+    description: `A ${CALL_OFFER.durationLabel} one-to-one working session on your own Claude Code or Claude Design project.`,
+    url: 'https://www.aiuxdesign.guide/call',
+    siteName: 'aiuxdesign.guide',
+    type: 'website',
+  },
+  alternates: { canonical: 'https://www.aiuxdesign.guide/call' },
+};
+
+// A booking page has nothing to gain from being indexed on its own, but nothing
+// to lose either — it is linked from the learning paths, which is how people
+// will reach it.
+const WHAT_HAPPENS = [
+  {
+    title: 'You send your project ahead',
+    body: 'A repo, a Figma file, or a description of where you are stuck. Sent when you book, so no time is spent on setup.',
+  },
+  {
+    title: `We work on it for ${CALL_OFFER.durationLabel}`,
+    body: 'Live, screen shared, on your actual project rather than a worked example.',
+  },
+  {
+    title: 'You keep whatever we make',
+    body: 'Prompts, config, code, or a plan — written down in the call, not sent afterwards.',
+  },
+];
+
+export default function CallPage() {
+  return (
+    <main className="min-h-screen bg-background-primary text-text-primary">
+      <Navbar />
+
+      {/* Hero */}
+      <section className="pt-12 md:pt-16 pb-12 md:pb-16 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="text-center max-w-3xl mx-auto">
+            <div className="flex items-center justify-center gap-2 mb-6">
+              <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-subtle text-accent-primary border border-info">
+                {CALL_OFFER.priceLabel} · {CALL_OFFER.durationLabel} · one to one
+              </span>
+            </div>
+            <h1
+              className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
+              style={{ color: 'var(--text-hero)' }}
+            >
+              Work through your project with me
+            </h1>
+            <p className="text-lg md:text-xl text-text-secondary mb-8">
+              The courses on this site are free. This is the version where we open your
+              project instead of an example, and spend {CALL_OFFER.durationLabel} on the
+              part you are actually stuck on.
+            </p>
+            <CallCheckout />
+          </div>
+        </div>
+      </section>
+
+      {/* What happens */}
+      <section className="py-16 md:py-20">
+        <div className="max-w-7xl mx-auto px-6">
+          <h2 className="text-2xl md:text-3xl font-bold mb-10 text-center">
+            How it works
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3 max-w-5xl mx-auto">
+            {WHAT_HAPPENS.map((step, i) => (
+              <div
+                key={step.title}
+                className="p-6 rounded-2xl border border-border-primary bg-surface-primary"
+              >
+                <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-accent-subtle text-accent-primary text-sm font-semibold mb-4">
+                  {i + 1}
+                </span>
+                <h3 className="font-semibold mb-2 text-text-primary">{step.title}</h3>
+                <p className="text-sm text-text-secondary">{step.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Refund — a stranger paying up front needs this said plainly. */}
+      <section className="pb-16 md:pb-24">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <p className="text-text-secondary">
+            If the session is not useful, tell me and I will refund it. No form to fill in.
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -749,3 +749,34 @@ html[data-theme="dark"] .newsletter-content a[style*="background-color: #162036"
     color: #162036 !important;
   }
 }
+
+/* Thin, faint scrollbar for panels that scroll inside the page — the pinned
+   guide sidebars, whose lesson lists overflow on longer courses (23 lessons on
+   the Claude Code path). The default track competes with the nav text for
+   attention on machines set to always show scrollbars.
+   Colour comes from --border-primary so it follows light/dark on its own.
+   Firefox uses scrollbar-width/color; WebKit needs the ::-webkit- rules. */
+.scrollbar-subtle {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-primary) transparent;
+}
+
+.scrollbar-subtle::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.scrollbar-subtle::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-subtle::-webkit-scrollbar-thumb {
+  background-color: var(--border-primary);
+  border-radius: 3px;
+}
+
+/* Darken slightly on hover so the control is findable when reached for, without
+   drawing the eye while the sidebar is at rest. */
+.scrollbar-subtle:hover::-webkit-scrollbar-thumb {
+  background-color: var(--text-secondary);
+}

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -9,6 +9,8 @@ import GuideSidebar from '@/components/guides/GuideSidebar';
 import OnThisPage from '@/components/guides/OnThisPage';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import GuidePDFCTA from '@/components/guides/GuidePDFCTA';
+import CallOfferBlock from '@/components/call/CallOfferBlock';
+import { guideCarriesCallOffer } from '@/lib/call-offer';
 import { siteConfig } from '@/config/seo';
 import { LessonSection } from '@/types/lesson';
 import {
@@ -341,6 +343,19 @@ export default async function LessonPage({ params }: LessonPageProps) {
                     customSuccessMessage="Subscribed! Watch for the next issue."
                   />
                 </div>
+              )}
+
+              {/* Paid 1:1 call offer, quiet one-line variant. On every lesson of
+                  the two Claude learning paths rather than only the last one:
+                  someone hits a blocker mid-course, which is exactly the moment
+                  the offer answers. Kept to a single line so a free course does
+                  not read as an advert. */}
+              {guideCarriesCallOffer(guide.slug) && (
+                <CallOfferBlock
+                  variant="compact"
+                  source={`lesson:${guide.slug}`}
+                  className="mb-12"
+                />
               )}
 
               {/* Related patterns — the upward half of the guide/pattern

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -236,7 +236,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
             {/* LEFT SIDEBAR — course nav (sticky on desktop) */}
             <aside className="hidden lg:block">
               <div
-                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto border-r border-border-primary pr-6"
+                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-r border-border-primary pr-6"
               >
                 <GuideSidebar guide={guide} currentLessonSlug={lessonSlug} />
               </div>
@@ -439,7 +439,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
             {/* RIGHT SIDEBAR — on this page (xl+ only) */}
             <aside className="hidden xl:block">
               <div
-                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto border-l border-border-primary pl-6"
+                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-l border-border-primary pl-6"
               >
                 <OnThisPage headings={headings} />
               </div>

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import { guides, getGuideBySlug } from '@/data/guides';
+import CallOfferBlock from '@/components/call/CallOfferBlock';
+import { guideCarriesCallOffer } from '@/lib/call-offer';
 import { generateGuideStructuredData } from '@/utils/structuredData';
 import { siteConfig } from '@/config/seo';
 import Navbar from '@/components/layout/Navbar';
@@ -296,6 +298,19 @@ export default async function GuidePage({ params }: GuidePageProps) {
                   })}
                 </ul>
               </section>
+
+              {/* Paid 1:1 call offer. Placed here — after the reader has seen what
+                  the course covers, before the lesson list — because the previous
+                  paid surface (/services) sat only in the footer and the post-audit
+                  screen and took zero enquiries in three months. Mid-page is the
+                  change being tested. Learning paths only; see call-offer.ts. */}
+              {guideCarriesCallOffer(guide.slug) && (
+                <CallOfferBlock
+                  variant="full"
+                  source={`guide:${guide.slug}`}
+                  className="mb-12"
+                />
+              )}
 
               {/* All lessons — bordered module cards with hoverable lesson rows */}
               <section className="mb-12">

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -227,7 +227,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
           <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] lg:gap-10">
             {/* LEFT SIDEBAR — course nav */}
             <aside className="hidden lg:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto border-r border-border-primary pr-6">
+              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-r border-border-primary pr-6">
                 <GuideSidebar guide={guide} currentIsOverview />
               </div>
             </aside>
@@ -442,7 +442,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
 
             {/* RIGHT SIDEBAR — on this page (xl+ only) */}
             <aside className="hidden xl:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto border-l border-border-primary pl-6">
+              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-l border-border-primary pl-6">
                 <OnThisPage headings={headings} />
               </div>
             </aside>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -98,6 +98,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      // Paid 1:1 session (commercial landing page). /call/booked is deliberately
+      // absent — it sits behind payment and is marked noindex.
+      url: `${baseUrl}/call`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${baseUrl}/handbook`,
       lastModified: new Date(),
       changeFrequency: 'monthly',

--- a/src/components/call/BookingEmbed.tsx
+++ b/src/components/call/BookingEmbed.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { CAL_BOOKING_URL } from '@/lib/call-offer';
+import { trackAuditEvent } from '@/lib/audit/analytics';
+
+/**
+ * The Cal.com booking calendar, shown immediately after payment.
+ *
+ * A plain iframe rather than Cal.com's embed script: it adds no dependency and
+ * no third-party JS to the page, and the booking page is the one place where a
+ * script failing to load would cost real money — the buyer has already paid.
+ *
+ * Firing call_booking_page_viewed here is how the paid-but-never-booked gap
+ * becomes visible: compare this count against call_checkout_clicked.
+ */
+export function BookingEmbed() {
+  useEffect(() => {
+    trackAuditEvent('call_booking_page_viewed');
+  }, []);
+
+  if (!CAL_BOOKING_URL) {
+    return (
+      <div className="p-6 rounded-2xl border border-border-primary bg-surface-primary text-center">
+        <p className="text-text-primary font-medium mb-2">
+          Your payment went through.
+        </p>
+        <p className="text-text-secondary">
+          The booking calendar is not connected yet — email me and I will send you
+          times directly.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-border-primary overflow-hidden bg-surface-primary">
+      <iframe
+        src={CAL_BOOKING_URL}
+        title="Pick a time for your session"
+        className="w-full"
+        style={{ height: 'min(80vh, 900px)', border: 'none' }}
+        loading="lazy"
+      />
+    </div>
+  );
+}
+
+export default BookingEmbed;

--- a/src/components/call/BookingEmbed.tsx
+++ b/src/components/call/BookingEmbed.tsx
@@ -26,7 +26,7 @@ export function BookingEmbed() {
           Your payment went through.
         </p>
         <p className="text-text-secondary">
-          The booking calendar is not connected yet — email me and I will send you
+          The booking calendar is not connected yet. Email me and I will send you
           times directly.
         </p>
       </div>

--- a/src/components/call/CallCheckout.tsx
+++ b/src/components/call/CallCheckout.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { CALL_OFFER, DODO_CALL_LINK, isCallOfferLive } from '@/lib/call-offer';
+import { trackAuditEvent } from '@/lib/audit/analytics';
+
+/**
+ * The pay button on /call, plus that page's instrumentation. Owning both in one
+ * component keeps the two halves of the metric together: how many people reached
+ * the page, and how many of those started checkout.
+ *
+ * Sends the buyer to the Dodo Static Payment Link. Nothing is charged, stored, or
+ * validated here — see src/lib/call-offer.ts for why.
+ */
+export function CallCheckout() {
+  useEffect(() => {
+    trackAuditEvent('call_page_viewed');
+  }, []);
+
+  if (!isCallOfferLive()) {
+    return (
+      <p className="text-text-secondary">
+        Booking is not open right now. Check back shortly.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <a
+        href={DODO_CALL_LINK}
+        onClick={() => trackAuditEvent('call_checkout_clicked')}
+        className="inline-flex items-center justify-center px-8 py-4 rounded-xl font-medium text-lg bg-accent-primary text-white hover:bg-accent-hover transition-colors"
+      >
+        Pay {CALL_OFFER.priceLabel} and pick a time
+      </a>
+      <p className="mt-4 text-sm text-text-secondary">
+        You will choose your slot straight after paying.
+      </p>
+    </div>
+  );
+}
+
+export default CallCheckout;

--- a/src/components/call/CallOfferBlock.tsx
+++ b/src/components/call/CallOfferBlock.tsx
@@ -81,8 +81,8 @@ export function CallOfferBlock({ variant = 'full', source, className = '' }: Cal
 
       <p className="text-text-secondary mb-6 max-w-2xl">
         The course is free and always will be. If you would rather work through your
-        own project with me — your codebase, your design system, your actual
-        blockers — book a session and we will do it live.
+        own project with me, book a session. Your codebase, your design system, your
+        actual blockers, worked through live.
       </p>
 
       <Link

--- a/src/components/call/CallOfferBlock.tsx
+++ b/src/components/call/CallOfferBlock.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+import { CALL_OFFER, isCallOfferLive } from '@/lib/call-offer';
+import { trackAuditEvent } from '@/lib/audit/analytics';
+
+interface CallOfferBlockProps {
+  /**
+   * 'full' — the bordered card on a learning-path overview, placed mid-page.
+   * 'compact' — a single quiet line at the foot of a lesson, so the offer is
+   * present on every lesson without turning the course into an advert.
+   */
+  variant?: 'full' | 'compact';
+  /** Which surface this instance sits on, sent with both events. */
+  source: string;
+  className?: string;
+}
+
+export function CallOfferBlock({ variant = 'full', source, className = '' }: CallOfferBlockProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Fire "shown" only when the block actually enters the viewport, not on mount.
+  // Placement is the whole point of this feature, so a render-time event would
+  // measure the wrong thing — it would count people who never scrolled to it.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            trackAuditEvent('call_offer_shown', { source, variant });
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [source, variant]);
+
+  // No payment link configured yet — render nothing rather than a dead CTA.
+  if (!isCallOfferLive()) return null;
+
+  const onClick = () => trackAuditEvent('call_offer_clicked', { source, variant });
+
+  if (variant === 'compact') {
+    return (
+      <div ref={ref} className={`text-sm text-text-secondary ${className}`}>
+        Stuck on your own project?{' '}
+        <Link
+          href="/call"
+          onClick={onClick}
+          className="text-accent-primary hover:text-accent-hover font-medium underline underline-offset-2 transition-colors"
+        >
+          Book {CALL_OFFER.durationLabel} with me for {CALL_OFFER.priceLabel}
+        </Link>
+        .
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={`p-6 md:p-8 rounded-2xl border border-border-primary bg-surface-primary ${className}`}
+    >
+      <div className="flex items-center gap-2 mb-4">
+        <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-subtle text-accent-primary border border-info">
+          {CALL_OFFER.priceLabel} · {CALL_OFFER.durationLabel}
+        </span>
+      </div>
+
+      <h2 className="text-xl md:text-2xl font-bold mb-3 text-text-primary">
+        Want a hand with your own project?
+      </h2>
+
+      <p className="text-text-secondary mb-6 max-w-2xl">
+        The course is free and always will be. If you would rather work through your
+        own project with me — your codebase, your design system, your actual
+        blockers — book a session and we will do it live.
+      </p>
+
+      <Link
+        href="/call"
+        onClick={onClick}
+        className="inline-flex items-center justify-center px-6 py-3 rounded-xl font-medium bg-accent-primary text-white hover:bg-accent-hover transition-colors"
+      >
+        Book a session · {CALL_OFFER.priceLabel}
+      </Link>
+    </div>
+  );
+}
+
+export default CallOfferBlock;

--- a/src/lib/audit/analytics.ts
+++ b/src/lib/audit/analytics.ts
@@ -101,6 +101,17 @@ export const AUDIT_EVENT_NAMES = [
   // Replaced the services upsell that used to hold this slot, so this is the
   // measurement of whether guide recommendations do better than that did.
   'audit_guide_clicked',
+  // Paid 1:1 call offer on the two Claude learning paths (src/lib/call-offer.ts).
+  // The whole point of the feature is placement, so `call_offer_shown` fires on
+  // scroll-into-view rather than on render — it counts people who actually saw
+  // the block, not people who loaded a page containing it.
+  'call_offer_shown',
+  'call_offer_clicked',
+  'call_page_viewed',
+  'call_checkout_clicked',
+  // Fired on /call/booked, which is reached only via the Dodo redirect. The gap
+  // between call_checkout_clicked and this is the paid-but-never-booked leak.
+  'call_booking_page_viewed',
 ] as const;
 
 export type AuditEvent = (typeof AUDIT_EVENT_NAMES)[number];

--- a/src/lib/call-offer.ts
+++ b/src/lib/call-offer.ts
@@ -1,0 +1,51 @@
+/**
+ * Paid 1:1 call offer — a $49 / 45-minute session sold to readers of the two
+ * Claude learning paths.
+ *
+ * Deliberately mirrors the /services decision (see the ServiceLead comment in
+ * prisma/schema.prisma): payment happens on a Dodo Static Payment Link, NOT in
+ * this repo. There is no checkout code, no webhook, no accounts, and no payment
+ * state in the database. The only thing the site does is send people to the link
+ * and catch them on the way back.
+ *
+ * Flow: offer block on a learning path -> /call -> Dodo checkout -> /call/booked
+ * (Cal.com embed). The Dodo link's `redirect_url` MUST point at /call/booked, or
+ * a paying customer lands nowhere and never books.
+ */
+
+export const CALL_OFFER = {
+  /** Shown to the buyer. Keep in sync with the amount configured on the Dodo link. */
+  priceLabel: '$49',
+  durationLabel: '45 minutes',
+  /** Used in headings and the page title. */
+  name: '45 minutes with me on your Claude Code project',
+} as const;
+
+/**
+ * The Dodo Static Payment Link. Public because it is just a URL the user is sent
+ * to — no secret is involved. When unset (local dev, or before the link exists)
+ * every call-offer surface renders nothing rather than a button that 404s.
+ */
+export const DODO_CALL_LINK = process.env.NEXT_PUBLIC_DODO_CALL_LINK ?? '';
+
+/**
+ * Full Cal.com booking URL, e.g. https://cal.com/imran/claude-45.
+ * Embedded in an iframe on /call/booked.
+ */
+export const CAL_BOOKING_URL = process.env.NEXT_PUBLIC_CAL_BOOKING_URL ?? '';
+
+/** True once the offer can actually be bought. Gates every surface. */
+export const isCallOfferLive = (): boolean => DODO_CALL_LINK.length > 0;
+
+/**
+ * Guides that carry the offer. Slug-gated rather than gated on `tool`, because
+ * `ai-ux-skills-guide` is also tool: 'Claude Code' but is product onboarding —
+ * putting a paid CTA on it would sell to people who came to install a free skill.
+ */
+export const CALL_OFFER_GUIDE_SLUGS: readonly string[] = [
+  'claude-code-learning-path',
+  'claude-design-learning-path',
+];
+
+export const guideCarriesCallOffer = (slug: string): boolean =>
+  CALL_OFFER_GUIDE_SLUGS.includes(slug);


### PR DESCRIPTION
## Why

`/services` has taken **zero enquiries in three months**, but it is only reachable from the footer, `/resources` (9 clicks in 6 months) and the post-audit screen (12 clicks). That zero measures placement, not demand — the offer has never been in front of anyone. Its intake form also asks for company, budget and timeline, which is a form for a founder buying an audit, not for a designer working through a Claude Code course.

The learning paths are where the interest actually is:

- **33% of all site clicks** across 75 pages
- Guide subscribers open at **53%** with **no unsubscribes**, against 31–35% open and 10–17% unsubscribe for the rest of the list

So: a $49 / 45-minute session, sold where those readers already are.

## What this adds

- **`/call`** — offer page. The pay button is a Dodo Static Payment Link.
- **`/call/booked`** — the Dodo redirect target. Cal.com calendar in an iframe, `noindex`.
- **`CallOfferBlock`** — full card mid-page on the two learning-path overviews (after "what you'll learn", before the lesson list), and a compact one-liner at the foot of every lesson. Learning paths only, slug-gated.
- **5 analytics events**, including `call_offer_shown` on scroll-into-view rather than render, since placement is the thing being tested, and `call_booking_page_viewed` so the paid-but-never-booked gap is visible.

Follows the June `/services` decision: no checkout code, no webhook, no accounts, no payment state in the database.

## Safe to merge before it is switched on

Every call-offer surface renders nothing while `NEXT_PUBLIC_DODO_CALL_LINK` is unset, and `/call` says booking is not open. Verified locally with the var removed. **Merging this changes nothing on the live site until the Vercel env vars are added.**

## Also in here

A separate commit makes the pinned guide sidebars' scrollbars thin and faint. Pre-existing behaviour, unrelated to the offer, kept as its own commit so it can be reverted independently.

## Set up outside the repo (done)

Dodo product live ($49 tax-inclusive, Edtech, verified account); Cal.com event live at `cal.com/aiuxdesign/claude-code-session` with a "what are we working on?" question; weekday evening availability added so US buyers see a 9:30am–1:15pm ET window.

## Still to do

- Add `NEXT_PUBLIC_DODO_CALL_LINK` and `NEXT_PUBLIC_CAL_BOOKING_URL` in Vercel
- Paste the booking link into the Dodo receipt email, for anyone who pays and closes the tab
- `/call` has no "why me" section — that copy is Imran's to write

https://claude.ai/code/session_01TZ9Rcr2CJnu2PA72fvPgBe