### PR TITLE
Move the audit results file onto z-index and error tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,9 @@ body {
   /* Semantic state borders */
   --border-success: #10b981;
   --border-error: #ef4444;
+  --surface-error: #fef2f2;
+  --text-error: #b91c1c;
+  --border-error-subtle: #fecaca;
   --border-warning: #f59e0b;
   --border-info: #3b82f6;
 
@@ -197,6 +200,9 @@ body {
     /* Semantic state borders (adjusted for dark mode) */
     --border-success: #059669;
     --border-error: #dc2626;
+    --surface-error: #1f0e0e;
+    --text-error: #fca5a5;
+    --border-error-subtle: #7f1d1d;
     --border-warning: #d97706;
     --border-info: #1d4ed8;
 
@@ -257,6 +263,9 @@ html[data-theme="dark"] {
 
   --border-success: #059669;
   --border-error: #dc2626;
+  --surface-error: #1f0e0e;
+  --text-error: #fca5a5;
+  --border-error-subtle: #7f1d1d;
   --border-warning: #d97706;
   --border-info: #1d4ed8;
 
@@ -313,6 +322,9 @@ html[data-theme="light"] {
 
   --border-success: #10b981;
   --border-error: #ef4444;
+  --surface-error: #fef2f2;
+  --text-error: #b91c1c;
+  --border-error-subtle: #fecaca;
   --border-warning: #f59e0b;
   --border-info: #3b82f6;
 

--- a/src/components/audit/FullPageResults.tsx
+++ b/src/components/audit/FullPageResults.tsx
@@ -116,14 +116,14 @@ function GapSidePanel({ gap, pinNumber, onClose }: { gap: TopGap; pinNumber: num
       <button
         onClick={onClose}
         aria-label="Close panel"
-        className="fixed lg:absolute inset-0 bg-black/50 lg:bg-black/30 z-40 lg:z-20 cursor-pointer animate-fade-in"
+        className="fixed lg:absolute inset-0 bg-black/50 lg:bg-black/30 z-modal lg:z-sticky cursor-pointer animate-fade-in"
       />
       {/* Sheet: fixed bottom sheet on mobile, right-anchored side panel on desktop. */}
       <aside
         role="dialog"
         aria-modal="true"
         aria-label={`Pattern detected: ${gap.pattern}`}
-        className="fixed lg:absolute inset-x-0 bottom-0 lg:inset-x-auto lg:top-0 lg:right-0 lg:bottom-0 w-full lg:w-[420px] max-h-[85vh] lg:max-h-none z-50 lg:z-30 bg-background-primary border-t lg:border-t-0 lg:border-l border-border-primary shadow-xl overflow-y-auto overscroll-contain rounded-t-2xl lg:rounded-none animate-slide-up lg:animate-slide-in"
+        className="fixed lg:absolute inset-x-0 bottom-0 lg:inset-x-auto lg:top-0 lg:right-0 lg:bottom-0 w-full lg:w-[420px] max-h-[85vh] lg:max-h-none z-toast lg:z-overlay bg-background-primary border-t lg:border-t-0 lg:border-l border-border-primary shadow-xl overflow-y-auto overscroll-contain rounded-t-2xl lg:rounded-none animate-slide-up lg:animate-slide-in"
       >
         {/* Drag handle (mobile only) — visual affordance for the bottom-sheet pattern. */}
         <div className="lg:hidden flex justify-center pt-2.5 pb-1" aria-hidden>
@@ -416,7 +416,7 @@ function EmptyAuditState({
                 </button>
               </div>
               {suggestError && (
-                <div className="mt-4 px-4 py-3 rounded-xl bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 text-base text-red-700 dark:text-red-300">
+                <div className="mt-4 px-4 py-3 rounded-xl bg-surface-error border border-border-error-subtle text-base text-text-error">
                   {suggestError}
                 </div>
               )}
@@ -1267,18 +1267,18 @@ export function FullPageResults({ results, onNewAudit, isAnalyzing, isDemoMode, 
                           <button
                             {...withFocusSuppress(() => setActiveScreenshotIndex((i) => (i - 1 + allScreenshots.length) % allScreenshots.length))}
                             aria-label="Previous screenshot"
-                            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black/60 hover:bg-black/80 text-white rounded-full flex items-center justify-center transition-colors cursor-pointer z-10"
+                            className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black/60 hover:bg-black/80 text-white rounded-full flex items-center justify-center transition-colors cursor-pointer z-dropdown"
                           >
                             <ChevronLeftIcon className="w-4 h-4" />
                           </button>
                           <button
                             {...withFocusSuppress(() => setActiveScreenshotIndex((i) => (i + 1) % allScreenshots.length))}
                             aria-label="Next screenshot"
-                            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black/60 hover:bg-black/80 text-white rounded-full flex items-center justify-center transition-colors cursor-pointer z-10"
+                            className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 bg-black/60 hover:bg-black/80 text-white rounded-full flex items-center justify-center transition-colors cursor-pointer z-dropdown"
                           >
                             <ChevronRightIcon className="w-4 h-4" />
                           </button>
-                          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 px-2 py-0.5 bg-black/60 text-white text-xs rounded-full z-10">
+                          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 px-2 py-0.5 bg-black/60 text-white text-xs rounded-full z-dropdown">
                             {activeScreenshotIndex + 1} / {allScreenshots.length}
                           </div>
                         </>
@@ -1289,7 +1289,7 @@ export function FullPageResults({ results, onNewAudit, isAnalyzing, isDemoMode, 
                           <span
                             key={pin.index}
                             aria-hidden
-                            className={`absolute z-10 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold border-2 transition-all bg-accent-primary text-white dark:text-gray-900 border-white dark:border-gray-900 ${
+                            className={`absolute z-dropdown -translate-x-1/2 -translate-y-1/2 flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold border-2 transition-all bg-accent-primary text-white dark:text-gray-900 border-white dark:border-gray-900 ${
                               isActive
                                 ? 'scale-125 shadow-lg ring-2 ring-black/15 dark:ring-white/25'
                                 : 'shadow-md ring-1 ring-black/10 dark:ring-white/20'
@@ -1381,7 +1381,7 @@ export function FullPageResults({ results, onNewAudit, isAnalyzing, isDemoMode, 
       {/* Mobile sticky CTA — the same single action as the rail, thumb-reachable.
           Hidden when a gap side-sheet is open so it doesn't compete with it. */}
       {!isDemoMode && savableSlugs.length > 0 && openPin === null && (
-        <div className="lg:hidden fixed inset-x-0 bottom-0 z-30 px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] bg-gradient-to-t from-background-primary via-background-primary to-background-primary/0">
+        <div className="lg:hidden fixed inset-x-0 bottom-0 z-overlay px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] bg-gradient-to-t from-background-primary via-background-primary to-background-primary/0">
           <button
             type="button"
             onClick={handleDownloadPack}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -18,12 +18,14 @@ export default {
           primary: 'var(--surface-primary)',
           secondary: 'var(--surface-secondary)',
           elevated: 'var(--surface-elevated)',
+          error: 'var(--surface-error)',
         },
         text: {
           primary: 'var(--text-primary)',
           secondary: 'var(--text-secondary)',
           tertiary: 'var(--text-tertiary)',
           disabled: 'var(--text-disabled)',
+          error: 'var(--text-error)',
         },
         // Minimal accent colors for interactive elements
         accent: {
@@ -38,6 +40,7 @@ export default {
           focus: 'var(--border-focus)',
           success: 'var(--border-success)',
           error: 'var(--border-error)',
+          'error-subtle': 'var(--border-error-subtle)',
           warning: 'var(--border-warning)',
           info: 'var(--border-info)',
         },


### PR DESCRIPTION
## Why

`FullPageResults.tsx` carried seven raw values the brand check blocks on. The check reads whole staged files rather than changed lines, so any unrelated edit to that file hit the wall — PR #88 had to be committed with `--no-verify` for exactly this reason. This clears it.

## z-index (6 sites)

Every token maps one-to-one onto the number already hardcoded — dropdown 10, sticky 20, overlay 30, modal 40, toast 50 — so each swap kept its original value and nothing restacks. The drawer, its backdrop, the mobile CTA bar and the screenshot pins all sit exactly where they did.

One naming compromise: the drawer stays at 50 as `z-toast`, which is an odd name for a side panel. Renaming it to the truer `z-modal` would drop it to 40 and collide with its own backdrop, so the number won over the name.

## Error tokens (1 site)

The error block had nothing compliant to swap in — the system had `--border-error` but no background or text equivalent. Added across all four theme blocks:

- `--surface-error`
- `--text-error`
- `--border-error-subtle` — the pale outline that block already used; the existing `--border-error` is saturated and would have changed how the state reads

Rendered colours are unchanged in light and dark.

## Verified

- Committed with hooks running, no bypass: brand validation and design audit both pass
- Typecheck clean on the touched file
- Error banner rendered locally against the old raw values — identical fill, border and text

https://claude.ai/code/session_01TZ9Rcr2CJnu2PA72fvPgBe