### PR TITLE
Restructure the courses index into a question-led Learn Map

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -812,6 +812,25 @@ html[data-theme="dark"] .newsletter-content a[style*="background-color: #162036"
   display: none;
 }
 
+/* RULE: no scrollbar anywhere in the courses area chrome.
+   The learn rail and the "On this page" column both scroll independently so
+   they can stay pinned, but neither should ever show a bar. Targeted by
+   element as well as by utility class so a missing class cannot quietly bring
+   one back. Content inside a lesson — the chat demos — is deliberately not
+   covered: there a scrollbar is the affordance telling you the transcript
+   scrolls. */
+nav[aria-label='Learn'],
+nav[aria-label='On this page'],
+[data-course-chrome='scroll'] {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+nav[aria-label='Learn']::-webkit-scrollbar,
+nav[aria-label='On this page']::-webkit-scrollbar,
+[data-course-chrome='scroll']::-webkit-scrollbar {
+  display: none;
+}
+
 .scrollbar-subtle {
   scrollbar-width: thin;
   scrollbar-color: var(--border-primary) transparent;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,8 +26,12 @@ body {
   /* Ground the learn console sits on. Its own token because the neutral
      ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
      close to separate a nav rail from the page behind it. */
-  --background-console: #e4e7ee;   /* ground */
-  --background-rail: #eff1f6;      /* nav rail — a real step off white */
+  /* Ground and rail are one tone on purpose. A ground darker than the rail
+     reads as a stripe down the left edge rather than as a margin; the
+     separation that matters is rail-to-content, and the border plus the white
+     content column does that. */
+  --background-console: #eff1f6;
+  --background-rail: #eff1f6;
 
   --surface-primary: #ffffff;
   --surface-secondary: #f9f9f9;
@@ -323,7 +327,7 @@ html[data-theme="light"] {
   /* Ground the learn console sits on. Its own token because the neutral
      ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
      close to separate a nav rail from the page behind it. */
-  --background-console: #e4e7ee;
+  --background-console: #eff1f6;
   --background-rail: #eff1f6;
 
   --surface-primary: #ffffff;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,6 +116,11 @@ body {
   --type-h3-leading: 1.3;
   --type-h3-tracking: -0.015em;
 
+  --type-lead-size: 1.25rem;         /* 20px — lead paragraphs, list-item titles */
+  --type-lead-weight: 400;
+  --type-lead-leading: 1.5;
+  --type-lead-tracking: -0.01em;
+
   --type-body-size: 1rem;            /* 16px — paragraph copy */
   --type-body-weight: 400;
   --type-body-leading: 1.6;
@@ -423,6 +428,12 @@ p {
   font-weight: var(--type-h3-weight);
   line-height: var(--type-h3-leading);
   letter-spacing: var(--type-h3-tracking);
+}
+.type-lead {
+  font-size: var(--type-lead-size);
+  font-weight: var(--type-lead-weight);
+  line-height: var(--type-lead-leading);
+  letter-spacing: var(--type-lead-tracking);
 }
 .type-body {
   font-size: var(--type-body-size);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,11 @@ body {
   --background-secondary: #fafafa;
   --background-tertiary: #f5f5f5;
   --background-grain: #F0F1F5;
+  /* Ground the learn console sits on. Its own token because the neutral
+     ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
+     close to separate a nav rail from the page behind it. */
+  --background-console: #e4e7ee;   /* ground */
+  --background-rail: #eff1f6;      /* nav rail — a real step off white */
 
   --surface-primary: #ffffff;
   --surface-secondary: #f9f9f9;
@@ -188,6 +193,8 @@ body {
     --background-secondary: #171717;
     --background-tertiary: #1f1f1f;
     --background-grain: #162036;
+    --background-console: #050505;
+    --background-rail: #141414;
 
     --surface-primary: #0f0f0f;
     --surface-secondary: #171717;
@@ -253,6 +260,7 @@ html[data-theme="dark"] {
   --background-secondary: #171717;
   --background-tertiary: #1f1f1f;
   --background-grain: #162036;
+  --background-console: #050505;
 
   --surface-primary: #0f0f0f;
   --surface-secondary: #171717;
@@ -312,6 +320,11 @@ html[data-theme="light"] {
   --background-secondary: #fafafa;
   --background-tertiary: #f5f5f5;
   --background-grain: #F0F1F5;
+  /* Ground the learn console sits on. Its own token because the neutral
+     ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
+     close to separate a nav rail from the page behind it. */
+  --background-console: #e4e7ee;
+  --background-rail: #eff1f6;
 
   --surface-primary: #ffffff;
   --surface-secondary: #f9f9f9;
@@ -790,6 +803,15 @@ html[data-theme="dark"] .newsletter-content a[style*="background-color: #162036"
 /* Disclosure rows in the learn rail. Native <details> gives expand/collapse
    with no JavaScript and, crucially, no navigation — clicking a course opens it
    in place instead of loading its page and throwing you back to the top. */
+/* The reserved scrollbar gutter is part of the <html> box, so the console's
+   ground — painted by a div inside <body> — cannot reach it, leaving a pale
+   strip down one edge. Tint the canvas itself when a console shell is on the
+   page. :has() rather than a class toggled in JS, so there is no flash before
+   hydration. */
+html:has(.learn-console-ground) {
+  background-color: var(--background-console);
+}
+
 .rail-disclosure > summary {
   list-style: none;
   cursor: pointer;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,7 @@ body {
   --ring-focus-warning: #f59e0b;
 
   --accent-primary: #162036;
+  --text-on-accent: #ffffff;   /* text sitting on accent-primary */
   --accent-hover: #1e2a42;
   --accent-subtle: #f5f5f5;
 
@@ -228,6 +229,7 @@ body {
     --ring-focus-warning: #d97706;
 
     --accent-primary: #ffffff;
+    --text-on-accent: #162036;
     --accent-hover: #e5e5e5;
     --accent-subtle: #171717;
 
@@ -288,6 +290,7 @@ html[data-theme="dark"] {
   --ring-focus-warning: #d97706;
 
   --accent-primary: #ffffff;
+  --text-on-accent: #162036;
   --accent-hover: #e5e5e5;
   --accent-subtle: #171717;
 
@@ -347,6 +350,7 @@ html[data-theme="light"] {
   --ring-focus-warning: #f59e0b;
 
   --accent-primary: #162036;
+  --text-on-accent: #ffffff;   /* text sitting on accent-primary */
   --accent-hover: #1e2a42;
   --accent-subtle: #f5f5f5;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,12 +26,11 @@ body {
   /* Ground the learn console sits on. Its own token because the neutral
      ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
      close to separate a nav rail from the page behind it. */
-  /* Ground and rail are one tone on purpose. A ground darker than the rail
-     reads as a stripe down the left edge rather than as a margin; the
-     separation that matters is rail-to-content, and the border plus the white
-     content column does that. */
-  --background-console: #eff1f6;
-  --background-rail: #eff1f6;
+  /* The rail is the darkest surface, not the ground. A ground darker than the
+     rail read as a stripe down the left edge; inverted, the rail reads as a
+     panel and the outer margin recedes. Content stays white. */
+  --background-console: #f7f8fb;
+  --background-rail: #e8ebf2;
 
   --surface-primary: #ffffff;
   --surface-secondary: #f9f9f9;
@@ -327,8 +326,8 @@ html[data-theme="light"] {
   /* Ground the learn console sits on. Its own token because the neutral
      ladder steps only 5 units (#fff -> #fafafa -> #f5f5f5), which is too
      close to separate a nav rail from the page behind it. */
-  --background-console: #eff1f6;
-  --background-rail: #eff1f6;
+  --background-console: #f7f8fb;
+  --background-rail: #e8ebf2;
 
   --surface-primary: #ffffff;
   --surface-secondary: #f9f9f9;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -783,6 +783,35 @@ html[data-theme="dark"] .newsletter-content a[style*="background-color: #162036"
    attention on machines set to always show scrollbars.
    Colour comes from --border-primary so it follows light/dark on its own.
    Firefox uses scrollbar-width/color; WebKit needs the ::-webkit- rules. */
+/* Scrollable without a visible scrollbar. For a nav rail that must stay pinned
+   while the content scrolls: sticky + its own overflow keeps it from snapping
+   back to the top on every navigation, and hiding the bar keeps the page
+   looking clean. Keyboard and wheel scrolling still work. */
+/* Disclosure rows in the learn rail. Native <details> gives expand/collapse
+   with no JavaScript and, crucially, no navigation — clicking a course opens it
+   in place instead of loading its page and throwing you back to the top. */
+.rail-disclosure > summary {
+  list-style: none;
+  cursor: pointer;
+}
+.rail-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+.rail-disclosure > summary .rail-chevron {
+  transition: transform 150ms ease;
+}
+.rail-disclosure[open] > summary .rail-chevron {
+  transform: rotate(90deg);
+}
+
+.scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 .scrollbar-subtle {
   scrollbar-width: thin;
   scrollbar-color: var(--border-primary) transparent;

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -239,15 +239,10 @@ export default async function LessonPage({ params }: LessonPageProps) {
               currentLessonSlug={lessonSlug}
             />
           }
-          aside={
-            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
-              <OnThisPage headings={headings} />
-            </div>
-          }
         >
           <div className="pt-10 pb-16">
             {/* CENTER — lesson article */}
-            <article className="max-w-3xl">
+            <div className="pt-2">
               {/* Breadcrumb */}
               <nav
                 className="mb-6 text-sm text-text-secondary"
@@ -317,6 +312,11 @@ export default async function LessonPage({ params }: LessonPageProps) {
                   )}
                 </div>
               </header>
+
+              {/* Body and TOC. The TOC starts under the header, so the lesson
+                  title and its meta get the full width. */}
+              <div className="xl:grid xl:grid-cols-[minmax(0,1fr)_240px] xl:gap-12">
+                <article className="max-w-[820px]">
 
               {/* Lesson body — fully expanded, server-rendered for crawlers */}
               <div className="mb-12">
@@ -392,53 +392,84 @@ export default async function LessonPage({ params }: LessonPageProps) {
                 </section>
               )}
 
-              {/* Previous / next lesson */}
+                </article>
+
+                <aside className="hidden xl:block">
+                  <div
+                    className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6"
+                    data-course-chrome="scroll"
+                  >
+                    <OnThisPage headings={headings} />
+                  </div>
+                </aside>
+              </div>
+
+              {/* Lesson footer, full width under both columns. Two panels
+                  rather than two bordered cards: Previous is where you came
+                  from, Up next is the one you are meant to take — so it carries
+                  the tint and the filled arrow. */}
               <nav
-                className="flex flex-col sm:flex-row justify-between items-stretch gap-4 border-t border-border-primary pt-8"
+                className="mt-16 grid grid-cols-1 border-t border-border-primary sm:grid-cols-2"
                 aria-label="Lesson navigation"
               >
                 {previous ? (
                   <Link
                     href={previous.url}
-                    className="flex-1 block p-5 rounded-xl border border-border-primary hover:border-accent-primary/40 hover:bg-surface-primary transition-colors group"
+                    className="group flex items-center gap-4 border-b border-border-primary py-8 pr-8 sm:border-b-0 sm:border-r"
                   >
-                    <span className="block text-xs text-text-secondary mb-1">
-                      ← Previous Lesson
+                    <span
+                      aria-hidden="true"
+                      className="type-lead text-text-secondary transition-colors group-hover:text-accent-primary"
+                    >
+                      ←
                     </span>
-                    <span className="block font-medium text-text-primary group-hover:text-accent-primary transition-colors">
-                      {previous.title}
+                    <span className="min-w-0">
+                      <span className="type-caption block text-text-secondary">
+                        Previous
+                      </span>
+                      <span className="type-lead block font-semibold text-text-primary transition-colors group-hover:text-accent-primary">
+                        {previous.title}
+                      </span>
                     </span>
                   </Link>
                 ) : (
-                  <div className="flex-1" />
+                  <div className="hidden sm:block" />
                 )}
+
                 {next ? (
                   <Link
                     href={next.url}
-                    className="flex-1 block p-5 rounded-xl border border-border-primary hover:border-accent-primary/40 hover:bg-surface-primary transition-colors text-right group"
+                    className="group flex items-center justify-between gap-4 bg-background-rail py-8 pl-8 pr-6"
                   >
-                    <span className="block text-xs text-text-secondary mb-1">
-                      Next Lesson →
+                    <span className="min-w-0">
+                      <span className="type-caption block text-text-secondary">
+                        Up next
+                      </span>
+                      <span className="type-lead block font-semibold text-text-primary transition-colors group-hover:text-accent-primary">
+                        {next.title}
+                      </span>
                     </span>
-                    <span className="block font-medium text-text-primary group-hover:text-accent-primary transition-colors">
-                      {next.title}
+                    <span
+                      aria-hidden="true"
+                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-pill bg-accent-primary text-text-on-accent"
+                    >
+                      →
                     </span>
                   </Link>
                 ) : (
-                  <div className="flex-1" />
+                  <div className="hidden sm:block" />
                 )}
               </nav>
 
-              {/* Back to course overview */}
-              <div className="mt-8 text-center">
+              <div className="border-t border-border-primary py-8 text-center">
                 <Link
                   href={`/guides/${guide.slug}`}
-                  className="inline-flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary"
+                  className="type-caption inline-flex items-center gap-2 text-text-secondary hover:text-text-primary"
                 >
                   ← Back to {guide.title} overview
                 </Link>
               </div>
-            </article>
+            </div>
 
           </div>
         </LearnShell>

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -225,7 +225,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
       ))}
 
       <main className="min-h-screen bg-background-primary text-text-primary">
-        <Navbar />
+        <Navbar inConsole />
 
         {/* Three-column docs layout.
             - Mobile: single column (sidebars hidden, breadcrumb gives context)

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -5,7 +5,7 @@ import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import LessonRenderer from '@/components/ui/LessonRenderer';
-import GuideSidebar from '@/components/guides/GuideSidebar';
+import LearnSidebar from '@/components/learn/LearnSidebar';
 import OnThisPage from '@/components/guides/OnThisPage';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import GuidePDFCTA from '@/components/guides/GuidePDFCTA';
@@ -233,13 +233,14 @@ export default async function LessonPage({ params }: LessonPageProps) {
             Grid math: left 240px, content 1fr (max ~720px), right 220px. */}
         <div className="max-w-[1400px] mx-auto px-6 pt-20 md:pt-24 pb-16">
           <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] lg:gap-10">
-            {/* LEFT SIDEBAR — course nav (sticky on desktop) */}
-            <aside className="hidden lg:block">
-              <div
-                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-r border-border-primary pr-6"
-              >
-                <GuideSidebar guide={guide} currentLessonSlug={lessonSlug} />
-              </div>
+            {/* LEFT SIDEBAR — the shared learn rail, with this course open
+                and the current lesson marked. See the course overview page for
+                why this replaced the page-local nav. */}
+            <aside>
+              <LearnSidebar
+                currentGuideSlug={guide.slug}
+                currentLessonSlug={lessonSlug}
+              />
             </aside>
 
             {/* CENTER — lesson article */}

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -440,7 +440,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
             {/* RIGHT SIDEBAR — on this page (xl+ only) */}
             <aside className="hidden xl:block">
               <div
-                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-l border-border-primary pl-6"
+                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll"
               >
                 <OnThisPage headings={headings} />
               </div>

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -6,6 +6,7 @@ import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import LessonRenderer from '@/components/ui/LessonRenderer';
 import LearnSidebar from '@/components/learn/LearnSidebar';
+import LearnShell from '@/components/learn/LearnShell';
 import OnThisPage from '@/components/guides/OnThisPage';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import GuidePDFCTA from '@/components/guides/GuidePDFCTA';
@@ -231,18 +232,20 @@ export default async function LessonPage({ params }: LessonPageProps) {
             - lg (≥1024px): left sidebar + content (no right sidebar yet)
             - xl (≥1280px): left sidebar + content + on-this-page TOC
             Grid math: left 240px, content 1fr (max ~720px), right 220px. */}
-        <div className="max-w-[1400px] mx-auto px-6 pt-20 md:pt-24 pb-16">
-          <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] lg:gap-10">
-            {/* LEFT SIDEBAR — the shared learn rail, with this course open
-                and the current lesson marked. See the course overview page for
-                why this replaced the page-local nav. */}
-            <aside>
-              <LearnSidebar
-                currentGuideSlug={guide.slug}
-                currentLessonSlug={lessonSlug}
-              />
-            </aside>
-
+        <LearnShell
+          sidebar={
+            <LearnSidebar
+              currentGuideSlug={guide.slug}
+              currentLessonSlug={lessonSlug}
+            />
+          }
+          aside={
+            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
+              <OnThisPage headings={headings} />
+            </div>
+          }
+        >
+          <div className="pt-10 pb-16">
             {/* CENTER — lesson article */}
             <article className="max-w-3xl">
               {/* Breadcrumb */}
@@ -437,16 +440,8 @@ export default async function LessonPage({ params }: LessonPageProps) {
               </div>
             </article>
 
-            {/* RIGHT SIDEBAR — on this page (xl+ only) */}
-            <aside className="hidden xl:block">
-              <div
-                className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll"
-              >
-                <OnThisPage headings={headings} />
-              </div>
-            </aside>
           </div>
-        </div>
+        </LearnShell>
 
         <Footer />
         <ScrollToTop />

--- a/src/app/guides/[slug]/[lesson]/page.tsx
+++ b/src/app/guides/[slug]/[lesson]/page.tsx
@@ -274,7 +274,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
                   H1, and iconified meta pill row */}
               <header className="mb-10">
                 <div
-                  className="border-t-2 border-accent-primary/30 w-12 mb-6"
+                  className="hidden"
                   aria-hidden="true"
                 />
                 <div className="flex flex-wrap items-center gap-2 mb-3">

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -11,6 +11,7 @@ import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import LearnSidebar from '@/components/learn/LearnSidebar';
+import LearnShell from '@/components/learn/LearnShell';
 import OnThisPage from '@/components/guides/OnThisPage';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import { getLessonsForCourse } from '@/lib/guides/lesson-urls';
@@ -168,18 +169,15 @@ export default async function GuidePage({ params }: GuidePageProps) {
       <main className="min-h-screen bg-background-primary text-text-primary">
         <Navbar />
 
-        {/* Three-column docs layout — same grid as /guides/[course]/[lesson]
-            so users see a consistent shell the moment they enter the course. */}
-        <div className="max-w-[1400px] mx-auto px-6 pt-10 pb-16">
-          <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] lg:gap-10">
-            {/* LEFT SIDEBAR — the shared learn rail. Same groups on every
-                page of the learning area; this course opens in place, so the
-                lesson nav is still here and the rest of the area stays
-                reachable instead of the page feeling like a dead end. */}
-            <aside>
-              <LearnSidebar currentGuideSlug={guide.slug} currentIsOverview />
-            </aside>
-
+        <LearnShell
+          sidebar={<LearnSidebar currentGuideSlug={guide.slug} currentIsOverview />}
+          aside={
+            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
+              <OnThisPage headings={headings} />
+            </div>
+          }
+        >
+          <div className="pt-10 pb-16">
             {/* CENTER — course overview article */}
             <article className="max-w-3xl">
               {/* Breadcrumb */}
@@ -440,14 +438,8 @@ export default async function GuidePage({ params }: GuidePageProps) {
               </div>
             </article>
 
-            {/* RIGHT SIDEBAR — on this page (xl+ only) */}
-            <aside className="hidden xl:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
-                <OnThisPage headings={headings} />
-              </div>
-            </aside>
           </div>
-        </div>
+        </LearnShell>
 
         <Footer />
         <ScrollToTop />

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { siteConfig } from '@/config/seo';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
-import GuideSidebar from '@/components/guides/GuideSidebar';
+import LearnSidebar from '@/components/learn/LearnSidebar';
 import OnThisPage from '@/components/guides/OnThisPage';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import { getLessonsForCourse } from '@/lib/guides/lesson-urls';
@@ -168,68 +168,16 @@ export default async function GuidePage({ params }: GuidePageProps) {
       <main className="min-h-screen bg-background-primary text-text-primary">
         <Navbar />
 
-        {/* Full-width hero — mirrors the /news hero treatment so every guide
-            opens with the same centered, branded moment instead of a bordered
-            card squeezed inside the article column. */}
-        <section className="pt-20 md:pt-24 pb-12 md:pb-16 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
-          <div className="max-w-7xl mx-auto px-6">
-            <div className="text-center max-w-4xl mx-auto">
-              <div className="flex items-center justify-center gap-2 mb-6">
-                <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-subtle text-accent-primary border border-info uppercase tracking-wider">
-                  {guide.tool} Course
-                </span>
-              </div>
-              <h1
-                className="text-4xl md:text-5xl lg:text-6xl font-semibold mb-6 text-text-primary leading-[1.1]"
-                style={{ textWrap: 'balance' }}
-              >
-                {guide.title}
-              </h1>
-              <p className="text-lg md:text-xl text-text-secondary mb-8 max-w-3xl mx-auto leading-relaxed">
-                {guide.excerpt || guide.description}
-              </p>
-              <div className="flex flex-wrap items-center justify-center gap-2 mb-8">
-                <span className="inline-flex items-center px-3 py-1.5 rounded-full bg-surface-primary border border-border-primary text-xs text-text-secondary font-medium">
-                  {guide.skillLevel}
-                </span>
-                {guide.lastUpdatedDate && (
-                  <span className="inline-flex items-center px-3 py-1.5 rounded-full bg-surface-primary border border-border-primary text-xs text-text-secondary font-medium">
-                    Updated{' '}
-                    {new Date(guide.lastUpdatedDate).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                )}
-              </div>
-              {firstLesson && (
-                <div className="flex justify-center">
-                  <Link
-                    href={firstLesson.url}
-                    className="inline-flex items-center gap-3 px-6 py-3 rounded-full bg-accent-primary text-white dark:text-gray-900 font-medium hover:bg-accent-hover transition-colors whitespace-nowrap"
-                  >
-                    Start Learning
-                    <ArrowRightIcon className="w-4 h-4" />
-                  </Link>
-                </div>
-              )}
-              <p className="text-base font-medium text-text-secondary mt-6">
-                {totalLessons} lessons · {totalMinutes} minutes · {moduleOrder.length} {moduleOrder.length === 1 ? 'module' : 'modules'}
-              </p>
-            </div>
-          </div>
-        </section>
-
         {/* Three-column docs layout — same grid as /guides/[course]/[lesson]
             so users see a consistent shell the moment they enter the course. */}
-        <div className="max-w-[1400px] mx-auto px-6 pt-12 md:pt-16 pb-16">
+        <div className="max-w-[1400px] mx-auto px-6 pt-10 pb-16">
           <div className="lg:grid lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)_220px] lg:gap-10">
-            {/* LEFT SIDEBAR — course nav */}
-            <aside className="hidden lg:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-r border-border-primary pr-6">
-                <GuideSidebar guide={guide} currentIsOverview />
-              </div>
+            {/* LEFT SIDEBAR — the shared learn rail. Same groups on every
+                page of the learning area; this course opens in place, so the
+                lesson nav is still here and the rest of the area stays
+                reachable instead of the page feeling like a dead end. */}
+            <aside>
+              <LearnSidebar currentGuideSlug={guide.slug} currentIsOverview />
             </aside>
 
             {/* CENTER — course overview article */}
@@ -251,6 +199,58 @@ export default async function GuidePage({ params }: GuidePageProps) {
                   </li>
                 </ol>
               </nav>
+
+              {/* Course header — inside the content column, not a
+                  full-width band above it. A band spans the whole page, which
+                  pushes the rail below it and makes each course read as its
+                  own site rather than a page of the learning area. */}
+              <header className="mb-12 border-b border-border-primary pb-10">
+                <div className="mb-4">
+                  <span className="type-eyebrow font-semibold text-accent-primary">
+                    {guide.tool} Course
+                  </span>
+                </div>
+                <h1
+                  className="type-h1 mb-4 text-text-primary"
+                  style={{ textWrap: 'balance' }}
+                >
+                  {guide.title}
+                </h1>
+                <p className="type-lead mb-6 text-text-secondary">
+                  {guide.excerpt || guide.description}
+                </p>
+                <div className="mb-6 flex flex-wrap items-center gap-2">
+                  <span className="type-caption inline-flex items-center rounded-pill border border-border-primary bg-surface-primary px-3 py-1 text-text-secondary">
+                    {guide.skillLevel}
+                  </span>
+                {guide.lastUpdatedDate && (
+                    <span className="type-caption inline-flex items-center rounded-pill border border-border-primary bg-surface-primary px-3 py-1 text-text-secondary">
+                    Updated{' '}
+                    {new Date(guide.lastUpdatedDate).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </span>
+                )}
+              </div>
+                {firstLesson && (
+                  <div className="flex">
+                  <Link
+                    href={firstLesson.url}
+                      className="type-body inline-flex items-center gap-3 whitespace-nowrap rounded-pill bg-accent-primary px-6 py-3 font-medium text-text-on-accent transition-colors hover:bg-accent-hover"
+                  >
+                    Start Learning
+                    <ArrowRightIcon className="w-4 h-4" />
+                  </Link>
+                </div>
+              )}
+                <p className="type-caption mt-6 text-text-secondary">
+                  {totalLessons} lessons · {totalMinutes} minutes ·{' '}
+                  {moduleOrder.length}{' '}
+                  {moduleOrder.length === 1 ? 'module' : 'modules'}
+                </p>
+              </header>
 
               {/* About this course */}
               <section className="mb-12">

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -167,7 +167,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
       ))}
 
       <main className="min-h-screen bg-background-primary text-text-primary">
-        <Navbar />
+        <Navbar inConsole />
 
         <LearnShell
           sidebar={<LearnSidebar currentGuideSlug={guide.slug} currentIsOverview />}

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -442,7 +442,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
 
             {/* RIGHT SIDEBAR — on this page (xl+ only) */}
             <aside className="hidden xl:block">
-              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-subtle border-l border-border-primary pl-6">
+              <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
                 <OnThisPage headings={headings} />
               </div>
             </aside>

--- a/src/app/guides/[slug]/page.tsx
+++ b/src/app/guides/[slug]/page.tsx
@@ -171,15 +171,10 @@ export default async function GuidePage({ params }: GuidePageProps) {
 
         <LearnShell
           sidebar={<LearnSidebar currentGuideSlug={guide.slug} currentIsOverview />}
-          aside={
-            <div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6" data-course-chrome="scroll">
-              <OnThisPage headings={headings} />
-            </div>
-          }
         >
           <div className="pt-10 pb-16">
             {/* CENTER — course overview article */}
-            <article className="max-w-3xl">
+            <div className="pt-2">
               {/* Breadcrumb */}
               <nav
                 className="mb-6 text-sm text-text-secondary"
@@ -249,6 +244,12 @@ export default async function GuidePage({ params }: GuidePageProps) {
                   {moduleOrder.length === 1 ? 'module' : 'modules'}
                 </p>
               </header>
+
+              {/* Body and TOC. The TOC starts here, under the header, so the
+                  title and the course meta get the full width — three columns
+                  all the way up squeezed the reading column to 768px. */}
+              <div className="xl:grid xl:grid-cols-[minmax(0,1fr)_240px] xl:gap-12">
+                <article className="max-w-[820px]">
 
               {/* About this course */}
               <section className="mb-12">
@@ -436,7 +437,18 @@ export default async function GuidePage({ params }: GuidePageProps) {
                   customSuccessMessage="Subscribed! Watch for the next issue."
                 />
               </div>
-            </article>
+                </article>
+
+                <aside className="hidden xl:block">
+                  <div
+                    className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto scrollbar-none border-l border-border-primary pl-6"
+                    data-course-chrome="scroll"
+                  >
+                    <OnThisPage headings={headings} />
+                  </div>
+                </aside>
+              </div>
+            </div>
 
           </div>
         </LearnShell>

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -16,6 +16,8 @@ import { guides } from '@/data/guides';
 import { learnMap } from '@/data/learn-map';
 import { resolveLearnSection } from '@/lib/learn-map';
 import LearnSection from '@/components/learn/LearnSection';
+import LearnSidebar from '@/components/learn/LearnSidebar';
+import { PATTERN_COUNT } from '@/data/pattern-count';
 import { siteConfig } from '@/config/seo';
 
 // Per-guide visual anchor — brand logo where available, generic chat icon for
@@ -284,7 +286,7 @@ function buildStructuredData() {
   ];
 }
 
-export default function GuidesPage() {
+export default async function GuidesPage() {
   const structuredData = buildStructuredData();
 
   return (
@@ -300,44 +302,74 @@ export default function GuidesPage() {
       <main className="min-h-screen bg-background-primary text-text-primary">
         <Navbar />
 
-        {/* Hero — server-rendered. Typography + spacing scaled to match the
-            homepage hero hierarchy (H1, subtitle, padding, margins). */}
+        {/* Hero — question-led, following the aihero.dev/learn model. The
+            page opens by asking the visitor what they want to do rather than
+            announcing what the site has; the numbered list doubles as the
+            table of contents and jumps into the matching section. Questions
+            come from learnMap so the hero cannot drift from the map below. */}
         <section className="pt-16 md:pt-20 pb-16 md:pb-20 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
           <div className="max-w-7xl mx-auto px-6">
-            <div className="text-center max-w-4xl mx-auto">
-              <p className="text-sm font-semibold uppercase tracking-wide text-accent-primary mb-4">
-                Free Learning Paths
-              </p>
-              <h1
-                className="text-5xl md:text-6xl lg:text-7xl font-bold mb-9"
-                style={{ color: 'var(--text-hero)' }}
-              >
-                AI Tool Guides for Designers
-              </h1>
-              <p className="text-2xl md:text-3xl text-text-secondary mb-12">
-                Free step-by-step courses on Claude Code, Cursor, GitHub
-                Copilot, GitHub, and conversational UI.
-              </p>
-              <p className="text-base text-text-secondary">
-                {guides.length} guides · {guides.reduce((sum, g) => sum + (g.lessons?.length || 0), 0)} lessons ·
-                All free, start instantly
-              </p>
-
-              {/* Hero email capture — mirrors the /news and /patterns hero
-                  treatment (stacked form + social proof) for a consistent,
-                  above-the-fold conversion surface. */}
-              <div className="mt-10 max-w-md mx-auto">
-                <InlineNewsletterSignup
-                  variant="hero"
-                  source="guides"
-                  customSubheading="Get daily AI product updates, pattern breakdowns & design insights"
-                  customButtonText="Solve my AI design overload →"
-                  customSuccessMessage="You're in! Watch for our next issue."
-                  stacked
-                />
-                <p className="text-base font-medium text-text-secondary mt-4">
-                  46,000+ reads · 50+ products analyzed daily
+            <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-16">
+              <div>
+                <p className="type-eyebrow font-semibold text-accent-primary mb-4">
+                  The Map
                 </p>
+                <h1
+                  className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
+                  style={{ color: 'var(--text-hero)' }}
+                >
+                  What do you want to do with AI UX?
+                </h1>
+                <p className="text-xl md:text-2xl text-text-secondary mb-4">
+                  Pick the question that sounds like you. Each one opens onto
+                  the courses, patterns and checklists that answer it, in the
+                  order they make sense.
+                </p>
+                <p className="type-body text-text-secondary mb-10">
+                  {guides.length} courses ·{' '}
+                  {guides.reduce((sum, g) => sum + (g.lessons?.length || 0), 0)}{' '}
+                  lessons · {PATTERN_COUNT} patterns · all free, no account
+                </p>
+
+                <ol className="border-t border-border-primary">
+                  {learnMap.map((section) => (
+                    <li key={section.id}>
+                      <a
+                        href={`#${section.id}`}
+                        className="group flex items-baseline gap-4 border-b border-border-primary py-4 transition-colors hover:text-accent-primary"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="type-eyebrow font-mono text-accent-primary"
+                        >
+                          {section.ordinal}
+                        </span>
+                        <span className="type-h3 text-text-primary group-hover:text-accent-primary">
+                          {section.question}
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              {/* Email capture kept from the previous hero — same above-the-fold
+                  conversion surface as /news and /patterns, moved beside the
+                  questions rather than under a centred headline. */}
+              <div className="mt-12 lg:mt-0">
+                <div className="rounded-card border border-border-primary bg-surface-primary p-6 lg:sticky lg:top-24">
+                  <InlineNewsletterSignup
+                    variant="hero"
+                    source="guides"
+                    customSubheading="Get daily AI product updates, pattern breakdowns & design insights"
+                    customButtonText="Solve my AI design overload →"
+                    customSuccessMessage="You're in! Watch for our next issue."
+                    stacked
+                  />
+                  <p className="type-body font-medium text-text-secondary mt-4">
+                    46,000+ reads · 50+ products analyzed daily
+                  </p>
+                </div>
               </div>
             </div>
           </div>
@@ -347,13 +379,16 @@ export default function GuidesPage() {
             answers it, in the order it makes sense. Resolved server-side; the
             resolver throws on a dead slug so this can never render a card
             pointing at a 404. */}
-        <div className="max-w-7xl mx-auto px-6">
-          {learnMap.map((section) => (
-            <LearnSection
-              key={section.id}
-              section={resolveLearnSection(section)}
-            />
-          ))}
+        <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
+          <LearnSidebar />
+          <div>
+            {learnMap.map((section) => (
+              <LearnSection
+                key={section.id}
+                section={resolveLearnSection(section)}
+              />
+            ))}
+          </div>
         </div>
 
         {/* All courses — the catalogue view. The map above is the

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,12 +1,9 @@
 import { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
 import {
   AcademicCapIcon,
-  BoltIcon,
-  BookmarkIcon,
-  ChatBubbleLeftRightIcon,
   ClockIcon,
+  BookmarkIcon,
 } from '@heroicons/react/24/outline';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
@@ -20,67 +17,6 @@ import LearnSidebar from '@/components/learn/LearnSidebar';
 import LearnShell from '@/components/learn/LearnShell';
 import { PATTERN_COUNT } from '@/data/pattern-count';
 import { siteConfig } from '@/config/seo';
-
-// Per-guide visual anchor — brand logo where available, generic chat icon for
-// the conversational UI guide. Drops into the card header so the grid reads
-// as an icon-led list rather than five identical text blocks.
-type GuideIconConfig =
-  | { src: string; alt: string }
-  | { component: typeof ChatBubbleLeftRightIcon; alt: string };
-
-const GUIDE_ICONS: Record<string, GuideIconConfig> = {
-  'claude-code-learning-path': {
-    src: '/images/logos/simple-icons/anthropic.svg',
-    alt: 'Claude',
-  },
-  'claude-design-learning-path': {
-    src: '/images/logos/simple-icons/claude-design.svg',
-    alt: 'Claude Design',
-  },
-  'cursor-learning-path': {
-    src: '/images/logos/simple-icons/cursor.svg',
-    alt: 'Cursor',
-  },
-  'github-copilot-learning-path': {
-    src: '/images/logos/simple-icons/githubcopilot.svg',
-    alt: 'GitHub Copilot',
-  },
-  'github-learning-path': {
-    src: '/images/logos/simple-icons/github.svg',
-    alt: 'GitHub',
-  },
-  'conversational-ui-guide': {
-    component: ChatBubbleLeftRightIcon,
-    alt: 'Conversational UI',
-  },
-  'ai-ux-skills-guide': {
-    component: BoltIcon,
-    alt: 'AI UX Skills',
-  },
-};
-
-function GuideIconTile({ slug }: { slug: string }) {
-  const meta = GUIDE_ICONS[slug];
-  if (!meta) return null;
-  return (
-    <div className="mb-5 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
-      {'component' in meta ? (
-        <meta.component
-          className="w-6 h-6 text-text-primary"
-          aria-hidden="true"
-        />
-      ) : (
-        <Image
-          src={meta.src}
-          alt=""
-          width={28}
-          height={28}
-          className="dark:invert"
-        />
-      )}
-    </div>
-  );
-}
 
 export const revalidate = 86400;
 
@@ -131,90 +67,6 @@ export const metadata: Metadata = {
     creator: siteConfig.creator.twitter,
   },
 };
-
-// Pre-computed card data so the server component can render without touching
-// the heavier client-side guide utilities (framer-motion, icons, etc.).
-interface GuideCard {
-  slug: string;
-  title: string;
-  tool: string;
-  tagline: string;
-  highlights: string[];
-  lessons: number;
-  readTime: number;
-}
-
-const guideMeta: Record<
-  string,
-  { tagline: string; highlights: string[] }
-> = {
-  'claude-code-learning-path': {
-    tagline: 'Start Here',
-    highlights: [
-      'Figma MCP design-to-code',
-      'AI-powered prototyping',
-      'Version control basics',
-    ],
-  },
-  'claude-design-learning-path': {
-    tagline: 'Prompt to prototype',
-    highlights: [
-      'Prompts → clickable HTML prototypes',
-      'Design system extracted from your codebase',
-      'Handoff to Claude Code for implementation',
-    ],
-  },
-  'cursor-learning-path': {
-    tagline: 'AI-native code editor',
-    highlights: [
-      'Tab autocomplete & AI suggestions',
-      'Chat & Composer for code generation',
-      'Design-to-code workflows',
-    ],
-  },
-  'github-copilot-learning-path': {
-    tagline: 'AI pair programmer',
-    highlights: [
-      'Inline code suggestions',
-      'AI pair programming',
-      'Works in VS Code, JetBrains & more',
-    ],
-  },
-  'github-learning-path': {
-    tagline: 'Version control fundamentals',
-    highlights: [
-      'Git basics for designers',
-      'Pull requests & code review',
-      'Team collaboration workflows',
-    ],
-  },
-  'conversational-ui-guide': {
-    tagline: 'Design & implementation',
-    highlights: [
-      'Chat bubbles, streaming & typing indicators',
-      'Context management & error recovery',
-      'Agentic AI patterns & accessibility',
-    ],
-  },
-  'ai-ux-skills-guide': {
-    tagline: 'Your agent, trained',
-    highlights: [
-      'Claude Code from zero: install and first session',
-      'Install a pack: zip or one-file installer',
-      'Triggering: symptom-first, no prompting',
-    ],
-  },
-};
-
-const cards: GuideCard[] = guides.map((g) => ({
-  slug: g.slug,
-  title: g.title,
-  tool: g.tool,
-  tagline: guideMeta[g.slug]?.tagline || '',
-  highlights: guideMeta[g.slug]?.highlights || [],
-  lessons: g.lessons?.length || 0,
-  readTime: g.readTime || 0,
-}));
 
 function buildStructuredData() {
   return [
@@ -408,61 +260,6 @@ export default async function GuidesPage() {
                 stacked
               />
             </div>
-          </div>
-        </section>
-
-        {/* All courses — the catalogue view. The map above is the
-            recommendation; this is the complete list, and it is what
-            guarantees every course keeps an internal link from this page
-            however the curation is edited. Also the target for the map
-            sections' "more" links. */}
-        <section
-          id="all-courses"
-          className="py-12 md:py-16 scroll-mt-24"
-        >
-          <div className="mb-8 max-w-3xl">
-            <h2 className="type-h2 text-text-primary mb-2">All courses</h2>
-            <p className="type-body text-text-secondary">
-              Every learning path on the site, {guides.length} in total. Free,
-              no account needed.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {cards.map((card) => (
-              <Link
-                key={card.slug}
-                href={`/guides/${card.slug}`}
-                className="block p-8 rounded-card border border-border-primary bg-surface-primary hover:border-accent-primary/40 hover:shadow-lg transition-all"
-              >
-                <GuideIconTile slug={card.slug} />
-                <p className="type-caption font-medium text-accent-primary mb-1">
-                  {card.tagline}
-                </p>
-                <h3 className="type-h3 text-text-primary mb-4">{card.title}</h3>
-                {card.highlights.length > 0 && (
-                  <ul className="space-y-2 mb-5">
-                    {card.highlights.map((h, i) => (
-                      <li
-                        key={i}
-                        className="flex items-center gap-2 type-body text-text-secondary"
-                      >
-                        <span className="w-1.5 h-1.5 rounded-pill bg-accent-primary flex-shrink-0" />
-                        {h}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-                <div className="flex items-center gap-4 type-body text-text-secondary pt-4 border-t border-border-primary">
-                  <span>{card.lessons} lessons</span>
-                  <span aria-hidden="true">·</span>
-                  <span>{card.readTime} min total</span>
-                  <span aria-hidden="true">·</span>
-                  <span className="font-medium text-accent-primary">
-                    Start Learning →
-                  </span>
-                </div>
-              </Link>
-            ))}
           </div>
         </section>
 

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -139,7 +139,6 @@ interface GuideCard {
   highlights: string[];
   lessons: number;
   readTime: number;
-  featured: boolean;
 }
 
 const guideMeta: Record<
@@ -204,13 +203,6 @@ const guideMeta: Record<
   },
 };
 
-const featuredSlugs = new Set([
-  'claude-code-learning-path',
-  'claude-design-learning-path',
-  'github-learning-path',
-  'conversational-ui-guide',
-]);
-
 const cards: GuideCard[] = guides.map((g) => ({
   slug: g.slug,
   title: g.title,
@@ -219,11 +211,7 @@ const cards: GuideCard[] = guides.map((g) => ({
   highlights: guideMeta[g.slug]?.highlights || [],
   lessons: g.lessons?.length || 0,
   readTime: g.readTime || 0,
-  featured: featuredSlugs.has(g.slug),
 }));
-
-const featuredCards = cards.filter((c) => c.featured);
-const otherCards = cards.filter((c) => !c.featured);
 
 function buildStructuredData() {
   return [
@@ -368,108 +356,60 @@ export default function GuidesPage() {
           ))}
         </div>
 
-        {/* Featured guides */}
-        {featuredCards.length > 0 && (
-          <section className="max-w-7xl mx-auto px-6 py-12 md:py-16 border-b border-border-primary">
-            <div className="flex items-center gap-2 mb-6">
-              <span className="px-3 py-1 rounded-full text-xs font-semibold bg-accent-subtle text-accent-primary border border-accent-primary/20">
-                Recommended Start
-              </span>
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {featuredCards.map((card) => (
-                <Link
-                  key={card.slug}
-                  href={`/guides/${card.slug}`}
-                  className="block p-8 rounded-3xl border border-border-primary bg-surface-secondary hover:border-accent-primary/40 hover:shadow-lg transition-all"
-                >
-                  <GuideIconTile slug={card.slug} />
-                  <p className="text-sm font-medium text-accent-primary mb-1">
-                    {card.tagline}
-                  </p>
-                  <h2 className="text-2xl font-bold text-text-primary mb-4">
-                    {card.title}
-                  </h2>
-                  {card.highlights.length > 0 && (
-                    <ul className="space-y-2 mb-5">
-                      {card.highlights.map((h, i) => (
-                        <li
-                          key={i}
-                          className="flex items-center gap-2 text-sm text-text-secondary"
-                        >
-                          <span className="w-1.5 h-1.5 rounded-full bg-accent-primary flex-shrink-0" />
-                          {h}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                  <div className="flex items-center gap-4 text-sm text-text-secondary pt-4 border-t border-border-primary">
-                    <span>{card.lessons} lessons</span>
-                    <span aria-hidden="true">·</span>
-                    <span>{card.readTime} min total</span>
-                    <span aria-hidden="true">·</span>
-                    <span className="font-medium text-accent-primary">
-                      Start Learning →
-                    </span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* More guides */}
-        {otherCards.length > 0 && (
-          <section className="max-w-7xl mx-auto px-6 py-12 md:py-16">
-            <div className="mb-8">
-              <h2 className="text-2xl font-bold text-text-primary mb-2">
-                More Guides
-              </h2>
-              <p className="text-text-secondary">
-                Other AI tools to expand your workflow
-              </p>
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {otherCards.map((card) => (
-                <Link
-                  key={card.slug}
-                  href={`/guides/${card.slug}`}
-                  className="block p-8 rounded-2xl border border-border-primary bg-surface-primary hover:border-accent-primary/40 hover:shadow-lg transition-all"
-                >
-                  <GuideIconTile slug={card.slug} />
-                  <p className="text-sm font-medium text-accent-primary mb-1">
-                    {card.tagline}
-                  </p>
-                  <h3 className="text-xl font-bold text-text-primary mb-4">
-                    {card.title}
-                  </h3>
-                  {card.highlights.length > 0 && (
-                    <ul className="space-y-2 mb-5">
-                      {card.highlights.map((h, i) => (
-                        <li
-                          key={i}
-                          className="flex items-center gap-2 text-sm text-text-secondary"
-                        >
-                          <span className="w-1.5 h-1.5 rounded-full bg-accent-primary flex-shrink-0" />
-                          {h}
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                  <div className="flex items-center gap-4 text-sm text-text-secondary pt-4 border-t border-border-primary">
-                    <span>{card.lessons} lessons</span>
-                    <span aria-hidden="true">·</span>
-                    <span>{card.readTime} min total</span>
-                    <span aria-hidden="true">·</span>
-                    <span className="font-medium text-accent-primary">
-                      Start Learning →
-                    </span>
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
+        {/* All courses — the catalogue view. The map above is the
+            recommendation; this is the complete list, and it is what
+            guarantees every course keeps an internal link from this page
+            however the curation is edited. Also the target for the map
+            sections' "more" links. */}
+        <section
+          id="all-courses"
+          className="max-w-7xl mx-auto px-6 py-12 md:py-16 scroll-mt-24"
+        >
+          <div className="mb-8 max-w-3xl">
+            <h2 className="type-h2 text-text-primary mb-2">All courses</h2>
+            <p className="type-body text-text-secondary">
+              Every learning path on the site, {guides.length} in total. Free,
+              no account needed.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {cards.map((card) => (
+              <Link
+                key={card.slug}
+                href={`/guides/${card.slug}`}
+                className="block p-8 rounded-card border border-border-primary bg-surface-primary hover:border-accent-primary/40 hover:shadow-lg transition-all"
+              >
+                <GuideIconTile slug={card.slug} />
+                <p className="type-caption font-medium text-accent-primary mb-1">
+                  {card.tagline}
+                </p>
+                <h3 className="type-h3 text-text-primary mb-4">{card.title}</h3>
+                {card.highlights.length > 0 && (
+                  <ul className="space-y-2 mb-5">
+                    {card.highlights.map((h, i) => (
+                      <li
+                        key={i}
+                        className="flex items-center gap-2 type-body text-text-secondary"
+                      >
+                        <span className="w-1.5 h-1.5 rounded-pill bg-accent-primary flex-shrink-0" />
+                        {h}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <div className="flex items-center gap-4 type-body text-text-secondary pt-4 border-t border-border-primary">
+                  <span>{card.lessons} lessons</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{card.readTime} min total</span>
+                  <span aria-hidden="true">·</span>
+                  <span className="font-medium text-accent-primary">
+                    Start Learning →
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
 
         {/* Intro prose — SEO content block, placed below the cards as
             supporting content so the hero-to-cards flow matches /patterns.

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -315,7 +315,7 @@ export default async function GuidesPage() {
             table of contents and jumps into the matching section. Questions
             come from learnMap so the hero cannot drift from the map below. */}
         <section className="border-b border-border-primary pb-12 pt-10 md:pb-16">
-          <div className="max-w-3xl">
+          <div>
                 <p className="type-eyebrow font-semibold text-accent-primary mb-4">
                   The Map
                 </p>

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -263,20 +263,18 @@ export default async function GuidesPage() {
           </div>
         </section>
 
-        {/* Intro prose — SEO content block, placed below the cards as
-            supporting content so the hero-to-cards flow matches /patterns.
-            Outer max-w-7xl matches the cards container above; inner max-w-3xl
-            stays narrow for readability and is left-aligned so it lines up
-            with the cards' left edge instead of floating mid-viewport. */}
-        <section className="pt-12 md:pt-16 pb-6 md:pb-8">
-          <div className="max-w-3xl mx-auto">
+        {/* Supporting prose. Left-aligned on the same 950px measure and the
+            same top rule as the map sections above — centred at a different
+            width it read as a different page stapled on the end. */}
+        <section className="border-t border-border-primary py-12 md:py-16">
+          <div className="max-w-[950px]">
             <h2
               id="why-guides"
-              className="scroll-mt-24 text-2xl md:text-3xl font-bold text-text-primary mb-6"
+              className="type-h2 scroll-mt-24 text-text-primary mb-6"
             >
               Why guides
             </h2>
-            <div className="prose prose-lg dark:prose-invert max-w-none text-text-secondary leading-relaxed space-y-4">
+            <div className="type-body space-y-4 text-text-secondary">
               <p>
                 The line between designer and developer is dissolving. Not
                 because designers are learning to code in the traditional
@@ -297,51 +295,50 @@ export default async function GuidesPage() {
               </p>
             </div>
 
-            {/* 3-up benefit row — visual reinforcement of the three claims
-                in the prose above. Centered cells, icon-tile design language
-                shared with the guide cards so the page reads as one system. */}
-            <ul className="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8">
-              <li className="flex flex-col items-center text-center">
+            {/* 3-up benefit row. Left-aligned like everything else on the
+                page; centred cells were the other half of the mismatch. */}
+            <ul className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
+              <li>
                 <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
                   <AcademicCapIcon
                     className="w-6 h-6 text-text-primary"
                     aria-hidden="true"
                   />
                 </div>
-                <h3 className="text-base font-semibold text-text-primary mb-2">
+                <h3 className="type-body font-semibold text-text-primary mb-2">
                   Built for designers
                 </h3>
-                <p className="text-sm text-text-secondary leading-relaxed">
+                <p className="type-caption text-text-secondary">
                   No coding background required. Each guide assumes a
                   designer starting point and lets the AI handle the syntax.
                 </p>
               </li>
-              <li className="flex flex-col items-center text-center">
+              <li>
                 <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
                   <ClockIcon
                     className="w-6 h-6 text-text-primary"
                     aria-hidden="true"
                   />
                 </div>
-                <h3 className="text-base font-semibold text-text-primary mb-2">
+                <h3 className="type-body font-semibold text-text-primary mb-2">
                   Hours, not weeks
                 </h3>
-                <p className="text-sm text-text-secondary leading-relaxed">
+                <p className="type-caption text-text-secondary">
                   Each course is a focused path you can work through in an
                   afternoon, no semester-long commitment to get fluent.
                 </p>
               </li>
-              <li className="flex flex-col items-center text-center">
+              <li>
                 <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
                   <BookmarkIcon
                     className="w-6 h-6 text-text-primary"
                     aria-hidden="true"
                   />
                 </div>
-                <h3 className="text-base font-semibold text-text-primary mb-2">
+                <h3 className="type-body font-semibold text-text-primary mb-2">
                   Bookmark any lesson
                 </h3>
-                <p className="text-sm text-text-secondary leading-relaxed">
+                <p className="type-caption text-text-secondary">
                   Every lesson has its own URL: save, share, or return to
                   the exact step you need without scrolling through a course.
                 </p>
@@ -350,24 +347,22 @@ export default async function GuidesPage() {
           </div>
         </section>
 
-        {/* FAQ — visible counterpart to the FAQPage JSON-LD above. Same
-            container pattern as the intro: max-w-7xl outer, max-w-3xl inner
-            left-aligned. Question h3s and answer p sizes bumped for
-            readability and stronger hierarchy. */}
-        <section className="py-12 md:py-16">
-          <div className="max-w-3xl mx-auto">
+        {/* FAQ — the visible counterpart the FAQPage markup requires. Same
+            measure and rule as every other section. */}
+        <section className="border-t border-border-primary py-12 md:py-16">
+          <div className="max-w-[950px]">
             <h2
               id="faq"
-              className="scroll-mt-24 text-2xl md:text-3xl font-bold text-text-primary mb-8"
+              className="type-h2 scroll-mt-24 text-text-primary mb-8"
             >
               Frequently Asked Questions
             </h2>
             <div className="space-y-8">
               <div>
-                <h3 className="text-xl font-semibold text-text-primary mb-3">
+                <h3 className="type-lead font-semibold text-text-primary mb-3">
                   Which AI tool should designers learn first?
                 </h3>
-                <p className="text-base md:text-lg text-text-secondary leading-relaxed">
+                <p className="type-body text-text-secondary">
                   Start with Claude Code. It has the most forgiving learning
                   curve, works with Figma via MCP for design-to-code
                   workflows, and lets you describe what you want in plain
@@ -377,10 +372,10 @@ export default async function GuidesPage() {
                 </p>
               </div>
               <div>
-                <h3 className="text-xl font-semibold text-text-primary mb-3">
+                <h3 className="type-lead font-semibold text-text-primary mb-3">
                   Do I need to know how to code to use these guides?
                 </h3>
-                <p className="text-base md:text-lg text-text-secondary leading-relaxed">
+                <p className="type-body text-text-secondary">
                   No. Every guide is written for designers with zero coding
                   background. We cover everything from terminal basics to
                   version control to shipping real prototypes. You describe
@@ -389,10 +384,10 @@ export default async function GuidesPage() {
                 </p>
               </div>
               <div>
-                <h3 className="text-xl font-semibold text-text-primary mb-3">
+                <h3 className="type-lead font-semibold text-text-primary mb-3">
                   Are these guides really free?
                 </h3>
-                <p className="text-base md:text-lg text-text-secondary leading-relaxed">
+                <p className="type-body text-text-secondary">
                   Yes, all guides are free. No email required to read them.
                   The tools themselves (Claude Code, Cursor, GitHub Copilot)
                   have free tiers, so we recommend starting with those and

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -1,10 +1,5 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import {
-  AcademicCapIcon,
-  ClockIcon,
-  BookmarkIcon,
-} from '@heroicons/react/24/outline';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
@@ -173,16 +168,21 @@ export default async function GuidesPage() {
                 <p className="type-eyebrow font-semibold text-accent-primary mb-4">
                   The Map
                 </p>
+                {/* "AI UX" is bound with a non-breaking space so the line can
+                    never break between them, and balance keeps the wrap even
+                    rather than leaving one short word on the last line. */}
+                {/* type-h1, not type-display: at 56px the question wrapped to
+                    two lines inside the 950px measure, and a two-line question
+                    reads as a paragraph rather than a prompt. */}
                 <h1
-                  className="type-display mb-6"
-                  style={{ color: 'var(--text-hero)' }}
+                  className="type-h1 mb-6"
+                  style={{ color: 'var(--text-hero)', textWrap: 'balance' }}
                 >
-                  What do you want to do with AI UX?
+                  What do you want to learn about AI&nbsp;UX?
                 </h1>
                 <p className="type-lead text-text-secondary mb-4">
                   Pick the question that sounds like you. Each one opens onto
-                  the courses, patterns and checklists that answer it, in the
-                  order they make sense.
+                  the courses, patterns and checklists that answer it.
                 </p>
                 <p className="type-caption text-text-secondary mb-10">
                   {guides.length} courses ·{' '}
@@ -295,55 +295,6 @@ export default async function GuidesPage() {
               </p>
             </div>
 
-            {/* 3-up benefit row. Left-aligned like everything else on the
-                page; centred cells were the other half of the mismatch. */}
-            <ul className="mt-10 grid grid-cols-1 gap-8 md:grid-cols-3">
-              <li>
-                <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
-                  <AcademicCapIcon
-                    className="w-6 h-6 text-text-primary"
-                    aria-hidden="true"
-                  />
-                </div>
-                <h3 className="type-body font-semibold text-text-primary mb-2">
-                  Built for designers
-                </h3>
-                <p className="type-caption text-text-secondary">
-                  No coding background required. Each guide assumes a
-                  designer starting point and lets the AI handle the syntax.
-                </p>
-              </li>
-              <li>
-                <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
-                  <ClockIcon
-                    className="w-6 h-6 text-text-primary"
-                    aria-hidden="true"
-                  />
-                </div>
-                <h3 className="type-body font-semibold text-text-primary mb-2">
-                  Hours, not weeks
-                </h3>
-                <p className="type-caption text-text-secondary">
-                  Each course is a focused path you can work through in an
-                  afternoon, no semester-long commitment to get fluent.
-                </p>
-              </li>
-              <li>
-                <div className="mb-4 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-background-primary border border-border-primary">
-                  <BookmarkIcon
-                    className="w-6 h-6 text-text-primary"
-                    aria-hidden="true"
-                  />
-                </div>
-                <h3 className="type-body font-semibold text-text-primary mb-2">
-                  Bookmark any lesson
-                </h3>
-                <p className="type-caption text-text-secondary">
-                  Every lesson has its own URL: save, share, or return to
-                  the exact step you need without scrolling through a course.
-                </p>
-              </li>
-            </ul>
           </div>
         </section>
 

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -17,6 +17,7 @@ import { learnMap } from '@/data/learn-map';
 import { resolveLearnSection } from '@/lib/learn-map';
 import LearnSection from '@/components/learn/LearnSection';
 import LearnSidebar from '@/components/learn/LearnSidebar';
+import LearnShell from '@/components/learn/LearnShell';
 import { PATTERN_COUNT } from '@/data/pattern-count';
 import { siteConfig } from '@/config/seo';
 
@@ -305,9 +306,7 @@ export default async function GuidesPage() {
         {/* One two-column shell for the whole page. The rail starts at the
             top, beside the hero, rather than below a full-width hero band —
             that is what makes the learn area read as one place. */}
-        <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
-          <LearnSidebar />
-          <div className="min-w-0">
+        <LearnShell sidebar={<LearnSidebar />}>
 
         {/* Hero — question-led, following the aihero.dev/learn model. The
             page opens by asking the visitor what they want to do rather than
@@ -604,8 +603,7 @@ export default async function GuidesPage() {
           </div>
         </section>
 
-        </div>
-        </div>
+        </LearnShell>
 
         <Footer />
         <ScrollToTop />

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -320,17 +320,17 @@ export default async function GuidesPage() {
                   The Map
                 </p>
                 <h1
-                  className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
+                  className="type-display mb-6"
                   style={{ color: 'var(--text-hero)' }}
                 >
                   What do you want to do with AI UX?
                 </h1>
-                <p className="text-xl md:text-2xl text-text-secondary mb-4">
+                <p className="type-lead max-w-2xl text-text-secondary mb-4">
                   Pick the question that sounds like you. Each one opens onto
                   the courses, patterns and checklists that answer it, in the
                   order they make sense.
                 </p>
-                <p className="type-body text-text-secondary mb-10">
+                <p className="type-caption text-text-secondary mb-10">
                   {guides.length} courses ·{' '}
                   {guides.reduce((sum, g) => sum + (g.lessons?.length || 0), 0)}{' '}
                   lessons · {PATTERN_COUNT} patterns · all free, no account

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -301,7 +301,7 @@ export default async function GuidesPage() {
       ))}
 
       <main className="min-h-screen bg-background-primary text-text-primary">
-        <Navbar />
+        <Navbar inConsole />
 
         {/* One two-column shell for the whole page. The rail starts at the
             top, beside the hero, rather than below a full-width hero band —

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -314,7 +314,10 @@ export default async function GuidesPage() {
             table of contents and jumps into the matching section. Questions
             come from learnMap so the hero cannot drift from the map below. */}
         <section className="border-b border-border-primary pb-12 pt-10 md:pb-16">
-          <div>
+          {/* Capped measure. The column runs ~1200px; prose set that wide is
+              tiring to read and is what made this page feel busy. Rows and
+              grids below keep the full width. */}
+          <div className="max-w-[950px]">
                 <p className="type-eyebrow font-semibold text-accent-primary mb-4">
                   The Map
                 </p>
@@ -324,7 +327,7 @@ export default async function GuidesPage() {
                 >
                   What do you want to do with AI UX?
                 </h1>
-                <p className="type-lead max-w-2xl text-text-secondary mb-4">
+                <p className="type-lead text-text-secondary mb-4">
                   Pick the question that sounds like you. Each one opens onto
                   the courses, patterns and checklists that answer it, in the
                   order they make sense.

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -302,15 +302,20 @@ export default async function GuidesPage() {
       <main className="min-h-screen bg-background-primary text-text-primary">
         <Navbar />
 
+        {/* One two-column shell for the whole page. The rail starts at the
+            top, beside the hero, rather than below a full-width hero band —
+            that is what makes the learn area read as one place. */}
+        <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
+          <LearnSidebar />
+          <div className="min-w-0">
+
         {/* Hero — question-led, following the aihero.dev/learn model. The
             page opens by asking the visitor what they want to do rather than
             announcing what the site has; the numbered list doubles as the
             table of contents and jumps into the matching section. Questions
             come from learnMap so the hero cannot drift from the map below. */}
-        <section className="pt-16 md:pt-20 pb-16 md:pb-20 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
-          <div className="max-w-7xl mx-auto px-6">
-            <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-16">
-              <div>
+        <section className="border-b border-border-primary pb-12 pt-10 md:pb-16">
+          <div className="max-w-3xl">
                 <p className="type-eyebrow font-semibold text-accent-primary mb-4">
                   The Map
                 </p>
@@ -359,28 +364,7 @@ export default async function GuidesPage() {
                       </a>
                     </li>
                   ))}
-                </ol>
-              </div>
-
-              {/* Email capture kept from the previous hero — same above-the-fold
-                  conversion surface as /news and /patterns, moved beside the
-                  questions rather than under a centred headline. */}
-              <div className="mt-12 lg:mt-0">
-                <div className="rounded-card border border-border-primary bg-surface-primary p-6 lg:sticky lg:top-24">
-                  <InlineNewsletterSignup
-                    variant="hero"
-                    source="guides"
-                    customSubheading="Get daily AI product updates, pattern breakdowns & design insights"
-                    customButtonText="Solve my AI design overload →"
-                    customSuccessMessage="You're in! Watch for our next issue."
-                    stacked
-                  />
-                  <p className="type-body font-medium text-text-secondary mt-4">
-                    46,000+ reads · 50+ products analyzed daily
-                  </p>
-                </div>
-              </div>
-            </div>
+            </ol>
           </div>
         </section>
 
@@ -388,17 +372,42 @@ export default async function GuidesPage() {
             answers it, in the order it makes sense. Resolved server-side; the
             resolver throws on a dead slug so this can never render a card
             pointing at a 404. */}
-        <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
-          <LearnSidebar />
-          <div>
-            {learnMap.map((section) => (
-              <LearnSection
-                key={section.id}
-                section={resolveLearnSection(section)}
-              />
-            ))}
-          </div>
+        <div>
+          {learnMap.map((section) => (
+            <LearnSection
+              key={section.id}
+              section={resolveLearnSection(section)}
+            />
+          ))}
         </div>
+
+        {/* Newsletter — placed after the map rather than in the hero. The
+            hero's job is now navigation: read the question, pick a path. An
+            email form there competes with that. By this point the visitor has
+            either found their path or has not, and both are reasonable moments
+            to offer a weekly digest. */}
+        <section className="border-t border-border-primary py-12 md:py-16">
+          <div className="rounded-card border border-border-primary bg-surface-primary p-6 md:grid md:grid-cols-2 md:items-center md:gap-10 md:p-8">
+            <div>
+              <p className="type-h3 text-text-primary">
+                Not sure where to start?
+              </p>
+              <p className="type-body text-text-secondary mt-1">
+                46,000+ reads · 50+ products analyzed daily
+              </p>
+            </div>
+            <div className="mt-4 w-full md:mt-0">
+              <InlineNewsletterSignup
+                variant="hero"
+                source="guides"
+                customSubheading="Get daily AI product updates, pattern breakdowns & design insights"
+                customButtonText="Solve my AI design overload →"
+                customSuccessMessage="You're in! Watch for our next issue."
+                stacked
+              />
+            </div>
+          </div>
+        </section>
 
         {/* All courses — the catalogue view. The map above is the
             recommendation; this is the complete list, and it is what
@@ -407,7 +416,7 @@ export default async function GuidesPage() {
             sections' "more" links. */}
         <section
           id="all-courses"
-          className="max-w-7xl mx-auto px-6 py-12 md:py-16 scroll-mt-24"
+          className="py-12 md:py-16 scroll-mt-24"
         >
           <div className="mb-8 max-w-3xl">
             <h2 className="type-h2 text-text-primary mb-2">All courses</h2>
@@ -460,7 +469,7 @@ export default async function GuidesPage() {
             Outer max-w-7xl matches the cards container above; inner max-w-3xl
             stays narrow for readability and is left-aligned so it lines up
             with the cards' left edge instead of floating mid-viewport. */}
-        <section className="max-w-7xl mx-auto px-6 pt-12 md:pt-16 pb-6 md:pb-8">
+        <section className="pt-12 md:pt-16 pb-6 md:pb-8">
           <div className="max-w-3xl mx-auto">
             <h2
               id="why-guides"
@@ -546,7 +555,7 @@ export default async function GuidesPage() {
             container pattern as the intro: max-w-7xl outer, max-w-3xl inner
             left-aligned. Question h3s and answer p sizes bumped for
             readability and stronger hierarchy. */}
-        <section className="max-w-7xl mx-auto px-6 py-12 md:py-16">
+        <section className="py-12 md:py-16">
           <div className="max-w-3xl mx-auto">
             <h2
               id="faq"
@@ -594,6 +603,9 @@ export default async function GuidesPage() {
             </div>
           </div>
         </section>
+
+        </div>
+        </div>
 
         <Footer />
         <ScrollToTop />

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -13,6 +13,9 @@ import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import { InlineNewsletterSignup } from '@/components/newsletter/InlineNewsletterSignup';
 import { guides } from '@/data/guides';
+import { learnMap } from '@/data/learn-map';
+import { resolveLearnSection } from '@/lib/learn-map';
+import LearnSection from '@/components/learn/LearnSection';
 import { siteConfig } from '@/config/seo';
 
 // Per-guide visual anchor — brand logo where available, generic chat icon for
@@ -351,6 +354,19 @@ export default function GuidesPage() {
             </div>
           </div>
         </section>
+
+        {/* The Learn Map — five questions, each opening onto the content that
+            answers it, in the order it makes sense. Resolved server-side; the
+            resolver throws on a dead slug so this can never render a card
+            pointing at a 404. */}
+        <div className="max-w-7xl mx-auto px-6">
+          {learnMap.map((section) => (
+            <LearnSection
+              key={section.id}
+              section={resolveLearnSection(section)}
+            />
+          ))}
+        </div>
 
         {/* Featured guides */}
         {featuredCards.length > 0 && (

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -331,21 +331,30 @@ export default async function GuidesPage() {
                   lessons · {PATTERN_COUNT} patterns · all free, no account
                 </p>
 
-                <ol className="border-t border-border-primary">
+                {/* Boxed chips in two columns, matching the reference. Each
+                    jumps to its section; the arrow says "this goes down the
+                    page" rather than off to another page. */}
+                <ol className="grid grid-cols-1 gap-3 md:grid-cols-2">
                   {learnMap.map((section) => (
                     <li key={section.id}>
                       <a
                         href={`#${section.id}`}
-                        className="group flex items-baseline gap-4 border-b border-border-primary py-4 transition-colors hover:text-accent-primary"
+                        className="group flex h-full items-center gap-3 rounded-card border border-border-primary bg-surface-primary px-4 py-4 transition-colors hover:border-accent-primary/40"
                       >
                         <span
                           aria-hidden="true"
-                          className="type-eyebrow font-mono text-accent-primary"
+                          className="type-eyebrow font-mono text-text-secondary"
                         >
                           {section.ordinal}
                         </span>
-                        <span className="type-h3 text-text-primary group-hover:text-accent-primary">
+                        <span className="type-body flex-1 font-semibold text-text-primary group-hover:text-accent-primary">
                           {section.question}
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          className="type-body text-text-secondary group-hover:text-accent-primary"
+                        >
+                          ↓
                         </span>
                       </a>
                     </li>

--- a/src/app/pattern-grid.tsx
+++ b/src/app/pattern-grid.tsx
@@ -64,51 +64,46 @@ export default function PatternGrid({ patterns, categories, allProducts, allIndu
   return (
     <>
       {/* Main Content with Sidebar */}
-      <div id="patterns" className="max-w-7xl mx-auto px-6 pt-12 md:pt-16 pb-24">
-        <div className="flex flex-col lg:flex-row gap-8">
-          {/* Desktop Sidebar */}
-          <aside className="hidden lg:block lg:w-64 flex-shrink-0">
-            <div className="bg-surface-primary dark:bg-gray-800/50 rounded-2xl p-6 border border-gray-200 dark:border-gray-700 shadow-card sticky top-24">
-              <h3
-                className="font-semibold text-xl mb-4 text-gray-900 dark:text-white"
+      <div id="patterns" className="pt-12 md:pt-16 pb-24">
+        {/* Categories as a horizontal filter row rather than a left column.
+            Inside the console that column sat beside the rail, so the page had
+            two nav columns before the first card; as a row it costs one line
+            and the grid gets the full width. */}
+        <div className="mb-8">
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => setSelectedCategory('All Categories')}
+              aria-pressed={selectedCategory === 'All Categories'}
+              className={`type-caption rounded-pill border px-4 py-2 transition-colors ${
+                selectedCategory === 'All Categories'
+                  ? 'border-transparent bg-text-primary font-semibold text-background-primary'
+                  : 'border-border-primary text-text-secondary hover:border-accent-primary/40 hover:text-text-primary'
+              }`}
+            >
+              All Patterns
+            </button>
+            {categories.map((cat) => (
+              <button
+                key={cat.id}
+                onClick={() => setSelectedCategory(cat.title)}
+                aria-pressed={selectedCategory === cat.title}
+                className={`type-caption rounded-pill border px-4 py-2 transition-colors ${
+                  selectedCategory === cat.title
+                    ? 'border-transparent bg-text-primary font-semibold text-background-primary'
+                    : 'border-border-primary text-text-secondary hover:border-accent-primary/40 hover:text-text-primary'
+                }`}
               >
-                Categories
-              </h3>
-              <ul className="space-y-2">
-                <li>
-                  <button
-                    onClick={() => setSelectedCategory('All Categories')}
-                    className={`w-full text-left px-3 py-2 rounded-lg transition-all ${
-                      selectedCategory === 'All Categories'
-                        ? 'bg-white font-semibold shadow-sm text-black'
-                        : 'hover:bg-white text-gray-700 dark:text-white hover:text-black'
-                    }`}
-                  >
-                    All Patterns
-                  </button>
-                </li>
-                {categories.map(cat => (
-                  <li key={cat.id}>
-                    <button
-                      onClick={() => setSelectedCategory(cat.title)}
-                      className={`w-full text-left px-3 py-2 rounded-lg transition-all ${
-                        selectedCategory === cat.title
-                          ? 'bg-white font-semibold shadow-sm text-black'
-                          : 'hover:bg-white text-gray-700 dark:text-white hover:text-black'
-                      }`}
-                    >
-                      {cat.title}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </aside>
+                {cat.title}
+              </button>
+            ))}
+          </div>
+        </div>
 
+        <div className="flex flex-col">
           {/* Patterns Grid */}
-          <div className="flex-1">
+          <div>
             {/* Search Bar */}
-            <div className="mb-6 bg-surface-primary dark:bg-gray-800/50 rounded-2xl p-5 border border-gray-200 dark:border-gray-700 shadow-card">
+            <div className="mb-6 bg-surface-primary rounded-card p-5 border border-border-primary shadow-card">
               <UnifiedSearchBar
                 placeholder="Search any AI Pattern you need"
                 value={searchQuery}
@@ -126,7 +121,7 @@ export default function PatternGrid({ patterns, categories, allProducts, allIndu
             </div>
 
             {/* Filter Bars */}
-            <div className="bg-surface-primary dark:bg-gray-800/50 rounded-2xl p-5 border border-gray-200 dark:border-gray-700 shadow-card mb-8">
+            <div className="bg-surface-primary rounded-card p-5 border border-border-primary shadow-card mb-8">
               <div className="flex flex-wrap items-start gap-3">
                 <ProductFilterBar
                   products={allProducts}
@@ -203,11 +198,11 @@ export default function PatternGrid({ patterns, categories, allProducts, allIndu
                       </p>
 
                       {/* Divider */}
-                      <div className="border-t border-gray-200 dark:border-gray-700 mb-6"></div>
+                      <div className="border-t border-border-primary mb-6"></div>
 
                       {/* Category */}
                       <div className="flex items-center gap-2 mb-6">
-                        <span className="px-3 py-1.5 rounded-full text-sm font-medium bg-gray-100 dark:bg-gray-800 text-text-secondary">
+                        <span className="px-3 py-1.5 rounded-pill type-caption bg-surface-secondary text-text-secondary">
                           {pattern.category}
                         </span>
                       </div>

--- a/src/app/patterns/page.tsx
+++ b/src/app/patterns/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import Navbar from '@/components/layout/Navbar';
+import LearnSidebar from '@/components/learn/LearnSidebar';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import SavedItemsBar from '@/components/handoff/SavedItemsBar';
@@ -134,11 +135,19 @@ export default function PatternsIndexPage() {
       <main className="min-h-screen bg-background-primary text-text-primary">
         <Navbar />
 
+      {/* Learn console shell — same rail as /guides and the course pages, so
+          Explore's own links do not drop you out of the area they belong to.
+          Opened directly under the navbar so the rail runs the full length of
+          the page rather than starting below a full-width hero. */}
+      <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
+        <LearnSidebar active="patterns" />
+        <div className="min-w-0">
+
         {/* Hero — restored to the pre-swap homepage treatment: large H1,
             subhead, and the company-logo carousel as social proof. Server-
             rendered for fast LCP. */}
-        <section className="pt-16 md:pt-20 pb-16 md:pb-20 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
-          <div className="max-w-7xl mx-auto px-6">
+        <section className="pt-10 pb-12 md:pb-16 border-b border-border-primary">
+          <div>
             <div className="text-center max-w-4xl mx-auto">
               <h1
                 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
@@ -214,6 +223,9 @@ export default function PatternsIndexPage() {
             The AI UX design pattern library for product designers and teams building AI-powered experiences. Each pattern is documented from 3+ real implementations across products like ChatGPT, Claude, GitHub Copilot, Midjourney, Google, and Notion, with examples, code demos, and research-backed guidance you can apply today.
           </p>
         </div>
+
+        </div>
+      </div>
 
         {/* Raised above SavedItemsBar, which is fixed to the bottom on this route. */}
         <ScrollToTop bottom={88} />

--- a/src/app/patterns/page.tsx
+++ b/src/app/patterns/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Navbar from '@/components/layout/Navbar';
 import LearnSidebar from '@/components/learn/LearnSidebar';
+import LearnShell from '@/components/learn/LearnShell';
 import Footer from '@/components/layout/Footer';
 import ScrollToTop from '@/components/ui/ScrollToTop';
 import SavedItemsBar from '@/components/handoff/SavedItemsBar';
@@ -139,50 +140,32 @@ export default function PatternsIndexPage() {
           Explore's own links do not drop you out of the area they belong to.
           Opened directly under the navbar so the rail runs the full length of
           the page rather than starting below a full-width hero. */}
-      <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
-        <LearnSidebar active="patterns" />
-        <div className="min-w-0">
+      <LearnShell sidebar={<LearnSidebar active="patterns" />}>
 
-        {/* Hero — restored to the pre-swap homepage treatment: large H1,
-            subhead, and the company-logo carousel as social proof. Server-
-            rendered for fast LCP. */}
-        <section className="pt-10 pb-12 md:pb-16 border-b border-border-primary">
-          <div>
-            <div className="text-center max-w-4xl mx-auto">
-              <h1
-                className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6"
-                style={{ color: 'var(--text-hero)', textWrap: 'balance' }}
-              >
-                {patterns.length} AI UX Design Patterns & Skills
-              </h1>
-
-              <p className="text-2xl md:text-3xl text-text-secondary mb-6">
-                How the world&apos;s best AI products design their experiences.
-              </p>
-
-              {/* Hero stays minimal on purpose: identity, quiet social proof,
-                  and a slim email capture (default component copy is the whole
-                  pitch: daily AIUX news disclosure, no extras). */}
-              <div className="mt-12">
-                <p className="text-[9px] font-bold text-text-secondary uppercase tracking-tight mb-4">
-                  Patterns used by leading companies
-                </p>
-                <LazyLogoCarousel companies={companyLogos} size="sm" gap="lg" />
-              </div>
-
-              <div className="mt-10 max-w-md mx-auto">
-                <InlineNewsletterSignup variant="hero" source="patterns-hero" stacked />
-                <p className="mt-3 text-sm font-medium text-text-secondary">
-                  Read by 1,500+ designers every month.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
+        {/* Page header, not a hero. Left-aligned title, one line of
+            description, then a meta row — the same shape the course and lesson
+            pages use, so every page in the console opens the same way. The
+            logo carousel and the email capture moved below the grid; they are
+            supporting material, not the first thing to read. */}
+        <header className="pt-10 pb-8 border-b border-border-primary">
+          <h1
+            className="type-h1 mb-3"
+            style={{ color: 'var(--text-hero)', textWrap: 'balance' }}
+          >
+            {patterns.length} AI UX Design Patterns &amp; Skills
+          </h1>
+          <p className="type-lead mb-5 max-w-2xl text-text-secondary">
+            How the world&apos;s best AI products design their experiences.
+          </p>
+          <p className="type-caption text-text-secondary">
+            {patterns.length} patterns · {categories.length} categories · free,
+            no account
+          </p>
+        </header>
 
         {/* Skills note — sits above the grid, sized to its own sentence rather
             than stretched across the page like a card. */}
-        <div className="max-w-7xl mx-auto px-6 pt-10 flex justify-center">
+        <div className="pt-8">
           <Link
             href="/skills"
             className="group inline-flex items-center gap-2.5 rounded-full border border-border-primary bg-surface-primary py-2 pl-3 pr-4 text-sm text-text-secondary hover:border-accent-primary transition-colors"
@@ -205,16 +188,25 @@ export default function PatternsIndexPage() {
           allIndustries={allIndustries}
         />
 
-        {/* Newsletter signup — same placement and copy that lived on the old
-            homepage to preserve the conversion surface for browsers. */}
-        <section className="max-w-2xl mx-auto px-6 py-16 md:py-20 text-center">
-          <h2 className="text-2xl md:text-3xl font-semibold text-text-primary mb-3">
+        {/* Social proof + newsletter. Both were in the hero; they read
+            better here, after someone has seen the patterns, and this is where
+            the page's only remaining email capture lives — the hero carried a
+            second, duplicate one. */}
+        <section className="border-t border-border-primary py-16 md:py-20">
+          <p className="type-eyebrow mb-4 text-center text-text-secondary">
+            Patterns used by leading companies
+          </p>
+          <LazyLogoCarousel companies={companyLogos} size="sm" gap="lg" />
+
+          <div className="mx-auto mt-14 max-w-2xl text-center">
+          <h2 className="type-h2 text-text-primary mb-3">
             Daily AI UX news
           </h2>
           <InlineNewsletterSignup variant="hero" source="patterns-grid" />
-          <p className="mt-4 text-sm text-text-secondary">
+          <p className="type-caption mt-4 text-text-secondary">
             Read by 1,500+ designers every month.
           </p>
+          </div>
         </section>
 
         {/* SEO — keyword-rich server-rendered text for Googlebot */}
@@ -224,8 +216,7 @@ export default function PatternsIndexPage() {
           </p>
         </div>
 
-        </div>
-      </div>
+      </LearnShell>
 
         {/* Raised above SavedItemsBar, which is fixed to the bottom on this route. */}
         <ScrollToTop bottom={88} />

--- a/src/app/patterns/page.tsx
+++ b/src/app/patterns/page.tsx
@@ -134,7 +134,7 @@ export default function PatternsIndexPage() {
       />
 
       <main className="min-h-screen bg-background-primary text-text-primary">
-        <Navbar />
+        <Navbar inConsole />
 
       {/* Learn console shell — same rail as /guides and the course pages, so
           Explore's own links do not drop you out of the area they belong to.

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -7,6 +7,7 @@ import { exampleProducts } from '@/lib/skills/usedBy';
 import { SkillsDirectory, type SkillRow } from '@/components/skills/SkillsDirectory';
 import { InstallCommand } from '@/components/skills/InstallCommand';
 import Navbar from '@/components/layout/Navbar';
+import LearnSidebar from '@/components/learn/LearnSidebar';
 import Footer from '@/components/layout/Footer';
 import SavedItemsBar from '@/components/handoff/SavedItemsBar';
 import Link from 'next/link';
@@ -57,9 +58,17 @@ export default function SkillsPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }} />
       <Navbar />
 
+      {/* Learn console shell — same rail as /guides and the course pages, so
+          Explore's own links do not drop you out of the area they belong to.
+          Opened directly under the navbar so the rail runs the full length of
+          the page rather than starting below a full-width hero. */}
+      <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
+        <LearnSidebar active="skills" />
+        <div className="min-w-0">
+
       {/* Hero Section - centered, matching resources/patterns/news style */}
-      <section className="pt-12 md:pt-16 pb-12 md:pb-16 bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
-        <div className="max-w-7xl mx-auto px-6">
+      <section className="pt-10 pb-12 md:pb-16 border-b border-border-primary">
+        <div>
           <div className="text-center max-w-4xl mx-auto">
             <div className="flex items-center justify-center gap-2 mb-6">
               <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-subtle text-accent-primary border border-info">
@@ -109,6 +118,9 @@ export default function SkillsPage() {
           </p>
         </div>
       </section>
+
+        </div>
+      </div>
 
       <SavedItemsBar />
       <Footer />

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -57,7 +57,7 @@ export default function SkillsPage() {
   return (
     <main className="min-h-screen bg-background-primary text-text-primary">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemList) }} />
-      <Navbar />
+      <Navbar inConsole />
 
       {/* Learn console shell — same rail as /guides and the course pages, so
           Explore's own links do not drop you out of the area they belong to.

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -8,6 +8,7 @@ import { SkillsDirectory, type SkillRow } from '@/components/skills/SkillsDirect
 import { InstallCommand } from '@/components/skills/InstallCommand';
 import Navbar from '@/components/layout/Navbar';
 import LearnSidebar from '@/components/learn/LearnSidebar';
+import LearnShell from '@/components/learn/LearnShell';
 import Footer from '@/components/layout/Footer';
 import SavedItemsBar from '@/components/handoff/SavedItemsBar';
 import Link from 'next/link';
@@ -62,44 +63,54 @@ export default function SkillsPage() {
           Explore's own links do not drop you out of the area they belong to.
           Opened directly under the navbar so the rail runs the full length of
           the page rather than starting below a full-width hero. */}
-      <div className="max-w-7xl mx-auto px-6 lg:grid lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-12">
-        <LearnSidebar active="skills" />
-        <div className="min-w-0">
+      <LearnShell sidebar={<LearnSidebar active="skills" />}>
 
-      {/* Hero Section - centered, matching resources/patterns/news style */}
-      <section className="pt-10 pb-12 md:pb-16 border-b border-border-primary">
-        <div>
-          <div className="text-center max-w-4xl mx-auto">
-            <div className="flex items-center justify-center gap-2 mb-6">
-              <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-accent-subtle text-accent-primary border border-info">
-                Free Claude Code Skills
-              </span>
-            </div>
-            <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6" style={{ color: 'var(--text-hero)' }}>
+      {/* Split page header, following the reference: identity on the left,
+          the thing you actually came to copy on the right. No centred hero —
+          inside a console column that reads as a page within a page. */}
+      <header className="border-b border-border-primary pt-10 pb-10">
+        <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_340px] lg:gap-12">
+          <div>
+            <p className="type-eyebrow mb-3 font-semibold text-accent-primary">
+              Free Claude Code Skills
+            </p>
+            <h1 className="type-h1 mb-3" style={{ color: 'var(--text-hero)' }}>
               {rows.length} AI UX Skills for Claude Code
             </h1>
-            <p className="text-lg md:text-xl text-text-secondary">
-              Design judgment your coding agent applies on its own. Install once, no prompting.
+            <p className="type-lead max-w-xl text-text-secondary">
+              Design judgment your coding agent applies on its own. Install
+              once, no prompting.
             </p>
-            <InstallCommand command={GENERIC_COMMAND} />
-            <p className="mt-4 text-sm text-text-secondary">
+            <p className="type-caption mt-4 text-text-secondary">
               New to skills?{' '}
-              <Link href="/guides/ai-ux-skills-guide" className="text-accent-primary hover:text-accent-hover font-medium transition-colors">
+              <Link
+                href="/guides/ai-ux-skills-guide"
+                className="font-medium text-accent-primary transition-colors hover:text-accent-hover"
+              >
                 Read how skills work
               </Link>{' '}
               (6 lessons, about 20 minutes).
             </p>
           </div>
-        </div>
-      </section>
 
-      <div className="max-w-7xl mx-auto px-6 py-12 md:py-16">
+          <div className="mt-8 lg:mt-0">
+            <div className="rounded-card border border-border-primary bg-surface-primary p-5">
+              <p className="type-caption mb-3 font-semibold text-text-primary">
+                Install the skills
+              </p>
+              <InstallCommand command={GENERIC_COMMAND} />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="py-12 md:py-16">
         <SkillsDirectory rows={rows} categories={categoryNames} />
       </div>
 
       {/* Bottom CTA */}
-      <section className="border-t border-border-primary bg-surface-primary">
-        <div className="max-w-7xl mx-auto px-6 py-16 md:py-20 text-center">
+      <section className="border-t border-border-primary">
+        <div className="py-16 md:py-20 text-center">
           <h2 className="text-2xl md:text-3xl font-semibold mb-4">Want several at once?</h2>
           <p className="text-text-secondary text-lg leading-relaxed mb-8 max-w-xl mx-auto">
             Save patterns as you browse and download them as one pack from your{' '}
@@ -119,8 +130,7 @@ export default function SkillsPage() {
         </div>
       </section>
 
-        </div>
-      </div>
+      </LearnShell>
 
       <SavedItemsBar />
       <Footer />

--- a/src/components/icons/AiuxMarkOutline.tsx
+++ b/src/components/icons/AiuxMarkOutline.tsx
@@ -1,0 +1,36 @@
+/**
+ * The aiux mark as a line icon: heart with a sparkle inside.
+ *
+ * The logo in the bar is a solid heart with the sparkle knocked out in white,
+ * which only works on the tinted disc it sits on. This is the same shape drawn
+ * as strokes, so it matches the heroicons outline set used by every other nav
+ * item — same 24 viewBox, same 1.5 stroke, currentColor throughout.
+ */
+export function AiuxMarkOutline({
+  className = 'w-5 h-5',
+}: {
+  className?: string;
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      width={20}
+      height={20}
+      className={className}
+      aria-hidden="true"
+    >
+      {/* heart */}
+      <path d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+      {/* sparkle */}
+      <path d="M12 8.6l1.05 2.35L15.4 12l-2.35 1.05L12 15.4l-1.05-2.35L8.6 12l2.35-1.05L12 8.6z" />
+    </svg>
+  );
+}
+
+export default AiuxMarkOutline;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,12 +3,14 @@ import { ThemeToggle } from '@/components/ui/ThemeToggle';
 
 export default function Footer() {
   return (
-    <footer className="border-t border-border-primary bg-[#F0F1F5] dark:bg-[#162036] bg-grain">
+    // A plain white band, not a card on a tinted ground. The card read as
+    // floating once the console pages tinted the canvas behind it.
+    <footer className="border-t border-border-primary bg-background-primary">
       {/* Multi-Column Footer Section — card-on-grain treatment lifted from
           the audit-page resources card so the homepage doesn't render two
           adjacent footers. */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-12 md:py-16 lg:py-20">
-        <div className="bg-background-primary rounded-2xl border border-border-primary p-8 md:p-10">
+      <div className="mx-auto max-w-[1600px] px-6 py-12 md:py-16 lg:py-20">
+        <div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-12">
             {/* Left Section: Branding */}
             <div className="lg:col-span-4">
@@ -283,7 +285,7 @@ export default function Footer() {
 
       {/* Bottom Bar */}
       <div className="border-t border-primary">
-        <div className="max-w-7xl mx-auto px-6 py-6">
+        <div className="mx-auto max-w-[1600px] px-6 py-6">
           <div className="flex flex-col md:flex-row items-center justify-between gap-4">
             {/* Email + theme toggle */}
             <div className="flex items-center gap-3">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
-  SparklesIcon,
   NewspaperIcon,
   MagnifyingGlassIcon,
   FolderIcon,
@@ -13,6 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 import dynamic from 'next/dynamic';
 import { useSavedCount } from '@/hooks/useSavedCount';
+import { AiuxMarkOutline } from '@/components/icons/AiuxMarkOutline';
 
 // Lazy-load SearchModal to defer loading pattern/guide/newsletter data until search is opened
 const SearchModal = dynamic(() => import('../ui/SearchModal'), { ssr: false });
@@ -118,7 +118,7 @@ const Navbar = ({
                 — /patterns was standing in for it. First position, ahead of the
                 learning material. */}
             <Link href="/audit" className={getLinkClasses('/audit')}>
-              <SparklesIcon className="w-5 h-5" />
+              <AiuxMarkOutline className="w-5 h-5" />
               <span className="hidden sm:inline relative">
                 Tool
                 <span className="invisible font-semibold block h-0" aria-hidden="true">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -17,7 +17,10 @@ import { useSavedCount } from '@/hooks/useSavedCount';
 // Lazy-load SearchModal to defer loading pattern/guide/newsletter data until search is opened
 const SearchModal = dynamic(() => import('../ui/SearchModal'), { ssr: false });
 
-const Navbar = () => {
+const Navbar = ({
+  /** True on learn-console pages, where the bar matches the console slab. */
+  inConsole = false,
+}: { inConsole?: boolean } = {}) => {
   const pathname = usePathname();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const { count: savedCount } = useSavedCount();
@@ -67,8 +70,25 @@ const Navbar = () => {
   };
 
   return (
-    <nav className="w-full py-5 bg-surface-primary border-b border-border-primary">
-      <div className="max-w-7xl mx-auto px-6">
+    // Two widths. Off the console the bar is full-width as it always was —
+    // those pages have full-bleed heroes, and a slabbed bar above one reads as
+    // a card floating over nothing. In the console the bar becomes the same
+    // 1600px slab as the shell, so the header lines up with the rail and the
+    // content column instead of stopping 320px short of them.
+    <nav
+      className={
+        inConsole
+          ? 'w-full bg-background-tertiary'
+          : 'w-full py-5 bg-surface-primary border-b border-border-primary'
+      }
+    >
+      <div
+        className={
+          inConsole
+            ? 'mx-auto max-w-[1600px] border-b border-border-primary bg-surface-primary px-6 py-5 lg:border-x'
+            : 'max-w-7xl mx-auto px-6'
+        }
+      >
         <div className="flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2 text-text-primary">
             <span className="flex items-center justify-center w-9 h-9 bg-accent-subtle rounded-full">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -6,7 +6,6 @@ import { usePathname } from 'next/navigation';
 import {
   NewspaperIcon,
   MagnifyingGlassIcon,
-  FolderIcon,
   AcademicCapIcon,
   BookmarkIcon,
 } from '@heroicons/react/24/outline';
@@ -147,15 +146,6 @@ const Navbar = ({
               </span>
             </Link>
 
-<Link href="/resources" className={getLinkClasses('/resources')}>
-              <FolderIcon className="w-5 h-5" />
-              <span className="hidden sm:inline relative">
-                Resources
-                <span className="invisible font-semibold block h-0" aria-hidden="true">
-                  Resources
-                </span>
-              </span>
-            </Link>
 
             <Link href="/dashboard" className={getLinkClasses('/dashboard')}>
               <span className="relative inline-flex">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -61,7 +61,7 @@ const Navbar = ({
   // Get link classes based on active state - minimal style with no layout shift
   const getLinkClasses = (href: string) => {
     const active = isActive(href);
-    return `flex items-center gap-2 px-2 sm:px-4 py-2 transition-colors duration-200 ease-out text-base border-b-2 ${
+    return `type-caption flex items-center gap-2 px-2 sm:px-3 py-1.5 transition-colors duration-200 ease-out border-b-2 ${
       active
         ? 'text-text-primary border-text-primary font-semibold'
         : 'text-text-secondary hover:text-text-primary border-transparent'
@@ -78,20 +78,20 @@ const Navbar = ({
     <nav
       className={
         inConsole
-          ? 'w-full bg-background-console'
-          : 'w-full py-5 bg-surface-primary border-b border-border-primary'
+          ? 'sticky top-0 z-sticky w-full bg-background-console'
+          : 'sticky top-0 z-sticky w-full py-3 bg-surface-primary border-b border-border-primary'
       }
     >
       <div
         className={
           inConsole
-            ? 'mx-auto max-w-[1600px] border-b border-border-primary bg-surface-primary px-6 py-5 lg:border-x'
+            ? 'mx-auto max-w-[1600px] border-b border-border-primary bg-surface-primary px-6 py-3 lg:border-x'
             : 'mx-auto max-w-[1600px] px-6'
         }
       >
         <div className="flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2 text-text-primary">
-            <span className="flex items-center justify-center w-9 h-9 bg-accent-subtle rounded-full">
+            <span className="flex items-center justify-center w-8 h-8 bg-accent-subtle rounded-full">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
@@ -107,7 +107,7 @@ const Navbar = ({
                 />
               </svg>
             </span>
-            <span className="text-xl font-medium tracking-tight">aiux</span>
+            <span className="type-lead font-medium tracking-tight">aiux</span>
           </Link>
 
           {/* Navigation Links */}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
-  Squares2X2Icon,
+  SparklesIcon,
   NewspaperIcon,
   MagnifyingGlassIcon,
   FolderIcon,
@@ -113,21 +113,19 @@ const Navbar = ({
 
           {/* Navigation Links */}
           <div className="flex items-center gap-1 sm:gap-3">
-            {/* Hidden inside the console, where the rail already lists Patterns
-                and Skills — repeating them in the bar is the same link twice on
-                one screen. Kept everywhere else: off the console the bar is the
-                only route to the pattern library. */}
-            {!inConsole && (
-              <Link href="/patterns" className={getLinkClasses('/patterns')}>
-                <Squares2X2Icon className="w-5 h-5" />
-                <span className="hidden sm:inline relative">
-                  Patterns & Skills
-                  <span className="invisible font-semibold block h-0" aria-hidden="true">
-                    Patterns & Skills
-                  </span>
+
+            {/* The audit is the product, and it had no entry in the bar at all
+                — /patterns was standing in for it. First position, ahead of the
+                learning material. */}
+            <Link href="/audit" className={getLinkClasses('/audit')}>
+              <SparklesIcon className="w-5 h-5" />
+              <span className="hidden sm:inline relative">
+                Tool
+                <span className="invisible font-semibold block h-0" aria-hidden="true">
+                  Tool
                 </span>
-              </Link>
-            )}
+              </span>
+            </Link>
 
             <Link href="/guides" className={getLinkClasses('/guides')}>
               <AcademicCapIcon className="w-5 h-5" />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -113,15 +113,21 @@ const Navbar = ({
 
           {/* Navigation Links */}
           <div className="flex items-center gap-1 sm:gap-3">
-            <Link href="/patterns" className={getLinkClasses('/patterns')}>
-              <Squares2X2Icon className="w-5 h-5" />
-              <span className="hidden sm:inline relative">
-                Patterns & Skills
-                <span className="invisible font-semibold block h-0" aria-hidden="true">
+            {/* Hidden inside the console, where the rail already lists Patterns
+                and Skills — repeating them in the bar is the same link twice on
+                one screen. Kept everywhere else: off the console the bar is the
+                only route to the pattern library. */}
+            {!inConsole && (
+              <Link href="/patterns" className={getLinkClasses('/patterns')}>
+                <Squares2X2Icon className="w-5 h-5" />
+                <span className="hidden sm:inline relative">
                   Patterns & Skills
+                  <span className="invisible font-semibold block h-0" aria-hidden="true">
+                    Patterns & Skills
+                  </span>
                 </span>
-              </span>
-            </Link>
+              </Link>
+            )}
 
             <Link href="/guides" className={getLinkClasses('/guides')}>
               <AcademicCapIcon className="w-5 h-5" />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -70,15 +70,16 @@ const Navbar = ({
   };
 
   return (
-    // Two widths. Off the console the bar is full-width as it always was —
-    // those pages have full-bleed heroes, and a slabbed bar above one reads as
-    // a card floating over nothing. In the console the bar becomes the same
-    // 1600px slab as the shell, so the header lines up with the rail and the
-    // content column instead of stopping 320px short of them.
+    // The content width is 1600px either way, so the logo and the nav items do
+    // not move when you cross between the console and the rest of the site —
+    // that shift was visible as a jump. Only the surround changes: off the
+    // console the bar is a plain full-width band, because those pages have
+    // full-bleed heroes and a slabbed bar above one reads as a card floating
+    // over nothing. In the console it becomes the same slab as the shell.
     <nav
       className={
         inConsole
-          ? 'w-full bg-background-tertiary'
+          ? 'w-full bg-background-console'
           : 'w-full py-5 bg-surface-primary border-b border-border-primary'
       }
     >
@@ -86,7 +87,7 @@ const Navbar = ({
         className={
           inConsole
             ? 'mx-auto max-w-[1600px] border-b border-border-primary bg-surface-primary px-6 py-5 lg:border-x'
-            : 'max-w-7xl mx-auto px-6'
+            : 'mx-auto max-w-[1600px] px-6'
         }
       >
         <div className="flex items-center justify-between">

--- a/src/components/learn/LearnItemCard.tsx
+++ b/src/components/learn/LearnItemCard.tsx
@@ -46,13 +46,17 @@ export default function LearnItemCard({
         </span>
 
         <div className="min-w-0 flex-1">
-          <p className="type-eyebrow text-text-secondary">{meta.join(' · ')}</p>
+          {/* A bordered pill, not loose text — it reads as a label and gives
+              the title something to sit under, the way the reference does it. */}
+          <span className="type-eyebrow inline-flex items-center rounded border border-border-primary px-2.5 py-1 text-text-secondary">
+            {meta.join(' · ')}
+          </span>
 
           {/* Capped measure, not the full row. */}
-          <h3 className="type-lead mt-1.5 max-w-[640px] font-semibold text-text-primary group-hover:text-accent-primary">
+          <h3 className="type-lead mt-3 max-w-[820px] font-bold text-text-primary group-hover:text-accent-primary">
             {item.title}
           </h3>
-          <p className="type-caption mt-1.5 line-clamp-2 max-w-[640px] text-text-secondary">
+          <p className="type-caption mt-2 line-clamp-2 max-w-[820px] text-text-secondary">
             {item.description}
           </p>
         </div>

--- a/src/components/learn/LearnItemCard.tsx
+++ b/src/components/learn/LearnItemCard.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import type { ResolvedLearnItem } from '@/lib/learn-map';
+
+/**
+ * One item in a Learn Map section.
+ *
+ * Server component by design — see the header of `src/lib/learn-map.ts`. Adding
+ * `'use client'` here would pull the whole pattern registry into the browser
+ * bundle for /guides.
+ *
+ * The meta line renders only when a read time exists, which is the minority
+ * case: only courses and lessons carry durations. A pattern showing its badge
+ * alone is the normal state, not a broken card.
+ */
+export default function LearnItemCard({ item }: { item: ResolvedLearnItem }) {
+  const meta: string[] = [];
+  if (item.lessonCount) meta.push(`${item.lessonCount} lessons`);
+  if (item.readTime) meta.push(`${item.readTime} min`);
+
+  return (
+    <li>
+      <Link
+        href={item.href}
+        className="group flex flex-col gap-1.5 rounded-2xl border border-border-primary bg-surface-primary p-5 transition-all hover:border-accent-primary/40 hover:shadow-lg sm:p-6"
+      >
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="rounded-full border border-accent-primary/20 bg-accent-subtle px-2.5 py-0.5 text-xs font-semibold text-accent-primary">
+            {item.badge}
+          </span>
+          {meta.length > 0 && (
+            <span className="text-xs text-text-secondary">
+              {meta.join(' · ')}
+            </span>
+          )}
+        </div>
+
+        <h3 className="text-lg font-bold text-text-primary group-hover:text-accent-primary sm:text-xl">
+          {item.title}
+        </h3>
+
+        <p className="text-sm leading-relaxed text-text-secondary">
+          {item.description}
+        </p>
+      </Link>
+    </li>
+  );
+}

--- a/src/components/learn/LearnItemCard.tsx
+++ b/src/components/learn/LearnItemCard.tsx
@@ -6,45 +6,60 @@ import type { ResolvedLearnItem } from '@/lib/learn-map';
  *
  * Rows rather than a card grid: the order of a section is the editorial
  * product, and a stacked list reads as a sequence where a grid reads as a
- * catalogue. It also gives each item a real internal hierarchy — metadata,
- * title, description — instead of three similarly-weighted lines.
+ * catalogue. It also gives each item a real internal hierarchy — ordinal,
+ * type, title, description.
  *
- * Everything sizes off the scale in globals.css: `type-eyebrow` for the
- * metadata line, `type-lead` for the title, `type-caption` for the
- * description. No raw font sizes.
+ * The card is full width but the TEXT is not. Left to fill the row, a
+ * description ran well over a thousand pixels of small type and the list read
+ * as a wall rather than a set of choices. Capping the text block is what makes
+ * the reference feel breathable at the same card width.
+ *
+ * Everything sizes off the scale in globals.css. No raw font sizes.
  *
  * Server component by design — see the header of `src/lib/learn-map.ts`.
- * Adding `'use client'` would pull the whole pattern registry into the browser
- * bundle for /guides.
  */
-export default function LearnItemCard({ item }: { item: ResolvedLearnItem }) {
-  // The type leads the metadata line rather than sitting in a pill. Read time
-  // and lesson count only exist for courses, so most rows show the type alone.
+export default function LearnItemCard({
+  item,
+  ordinal,
+}: {
+  item: ResolvedLearnItem;
+  /** Position within the section, shown as 01, 02 … like the reference. */
+  ordinal: number;
+}) {
+  // Duration only exists for courses. Kept beside the type rather than on its
+  // own line — three facts stacked above the title was most of the clutter.
   const meta = [item.badge];
   if (item.lessonCount) meta.push(`${item.lessonCount} lessons`);
-  if (item.readTime) meta.push(`${item.readTime} min read`);
+  if (item.readTime) meta.push(`${item.readTime} min`);
 
   return (
     <li>
       <Link
         href={item.href}
-        className="group flex items-center gap-5 rounded-card border border-border-primary bg-surface-primary px-5 py-4 transition-all hover:border-accent-primary/40 hover:shadow-card sm:px-6"
+        className="group flex items-start gap-5 rounded-card border border-border-primary bg-surface-primary px-6 py-6 transition-all hover:border-accent-primary/40 hover:shadow-card"
       >
+        <span
+          aria-hidden="true"
+          className="type-caption mt-0.5 w-6 shrink-0 font-mono text-text-secondary"
+        >
+          {String(ordinal).padStart(2, '0')}
+        </span>
+
         <div className="min-w-0 flex-1">
           <p className="type-eyebrow text-text-secondary">{meta.join(' · ')}</p>
-          <h3 className="type-lead mt-1 font-semibold text-text-primary group-hover:text-accent-primary">
+
+          {/* Capped measure, not the full row. */}
+          <h3 className="type-lead mt-1.5 max-w-[640px] font-semibold text-text-primary group-hover:text-accent-primary">
             {item.title}
           </h3>
-          {/* Clamped: source descriptions run from one line to a full
-              paragraph, and an unclamped row makes the list ragged. */}
-          <p className="type-caption mt-1 line-clamp-2 text-text-secondary">
+          <p className="type-caption mt-1.5 line-clamp-2 max-w-[640px] text-text-secondary">
             {item.description}
           </p>
         </div>
 
         <span
           aria-hidden="true"
-          className="type-lead shrink-0 text-text-secondary transition-colors group-hover:text-accent-primary"
+          className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-pill border border-border-primary text-text-secondary transition-colors group-hover:border-accent-primary/40 group-hover:text-accent-primary"
         >
           →
         </span>

--- a/src/components/learn/LearnItemCard.tsx
+++ b/src/components/learn/LearnItemCard.tsx
@@ -2,47 +2,52 @@ import Link from 'next/link';
 import type { ResolvedLearnItem } from '@/lib/learn-map';
 
 /**
- * One item in a Learn Map section.
+ * One item in a Learn Map section, as a full-width row.
  *
- * Server component by design — see the header of `src/lib/learn-map.ts`. Adding
- * `'use client'` here would pull the whole pattern registry into the browser
+ * Rows rather than a card grid: the order of a section is the editorial
+ * product, and a stacked list reads as a sequence where a grid reads as a
+ * catalogue. It also gives each item a real internal hierarchy — metadata,
+ * title, description — instead of three similarly-weighted lines.
+ *
+ * Everything sizes off the scale in globals.css: `type-eyebrow` for the
+ * metadata line, `type-lead` for the title, `type-caption` for the
+ * description. No raw font sizes.
+ *
+ * Server component by design — see the header of `src/lib/learn-map.ts`.
+ * Adding `'use client'` would pull the whole pattern registry into the browser
  * bundle for /guides.
- *
- * The meta line renders only when a read time exists, which is the minority
- * case: only courses and lessons carry durations. A pattern showing its badge
- * alone is the normal state, not a broken card.
  */
 export default function LearnItemCard({ item }: { item: ResolvedLearnItem }) {
-  const meta: string[] = [];
+  // The type leads the metadata line rather than sitting in a pill. Read time
+  // and lesson count only exist for courses, so most rows show the type alone.
+  const meta = [item.badge];
   if (item.lessonCount) meta.push(`${item.lessonCount} lessons`);
-  if (item.readTime) meta.push(`${item.readTime} min`);
+  if (item.readTime) meta.push(`${item.readTime} min read`);
 
   return (
     <li>
       <Link
         href={item.href}
-        className="group flex h-full flex-col gap-1.5 rounded-card border border-border-primary bg-surface-primary p-5 transition-all hover:border-accent-primary/40 hover:shadow-lg sm:p-6"
+        className="group flex items-center gap-5 rounded-card border border-border-primary bg-surface-primary px-5 py-4 transition-all hover:border-accent-primary/40 hover:shadow-card sm:px-6"
       >
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="type-caption rounded-pill border border-accent-primary/20 bg-accent-subtle px-3 py-0.5 font-semibold text-accent-primary">
-            {item.badge}
-          </span>
-          {meta.length > 0 && (
-            <span className="type-caption text-text-secondary">
-              {meta.join(' · ')}
-            </span>
-          )}
+        <div className="min-w-0 flex-1">
+          <p className="type-eyebrow text-text-secondary">{meta.join(' · ')}</p>
+          <h3 className="type-lead mt-1 font-semibold text-text-primary group-hover:text-accent-primary">
+            {item.title}
+          </h3>
+          {/* Clamped: source descriptions run from one line to a full
+              paragraph, and an unclamped row makes the list ragged. */}
+          <p className="type-caption mt-1 line-clamp-2 text-text-secondary">
+            {item.description}
+          </p>
         </div>
 
-        <h3 className="type-h3 text-text-primary group-hover:text-accent-primary">
-          {item.title}
-        </h3>
-
-        {/* Clamped: source descriptions vary from one line to a full paragraph,
-            and an unclamped card sets the height of everything beside it. */}
-        <p className="type-body line-clamp-3 text-text-secondary">
-          {item.description}
-        </p>
+        <span
+          aria-hidden="true"
+          className="type-lead shrink-0 text-text-secondary transition-colors group-hover:text-accent-primary"
+        >
+          →
+        </span>
       </Link>
     </li>
   );

--- a/src/components/learn/LearnItemCard.tsx
+++ b/src/components/learn/LearnItemCard.tsx
@@ -21,24 +21,26 @@ export default function LearnItemCard({ item }: { item: ResolvedLearnItem }) {
     <li>
       <Link
         href={item.href}
-        className="group flex flex-col gap-1.5 rounded-2xl border border-border-primary bg-surface-primary p-5 transition-all hover:border-accent-primary/40 hover:shadow-lg sm:p-6"
+        className="group flex h-full flex-col gap-1.5 rounded-card border border-border-primary bg-surface-primary p-5 transition-all hover:border-accent-primary/40 hover:shadow-lg sm:p-6"
       >
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="rounded-full border border-accent-primary/20 bg-accent-subtle px-2.5 py-0.5 text-xs font-semibold text-accent-primary">
+          <span className="type-caption rounded-pill border border-accent-primary/20 bg-accent-subtle px-3 py-0.5 font-semibold text-accent-primary">
             {item.badge}
           </span>
           {meta.length > 0 && (
-            <span className="text-xs text-text-secondary">
+            <span className="type-caption text-text-secondary">
               {meta.join(' · ')}
             </span>
           )}
         </div>
 
-        <h3 className="text-lg font-bold text-text-primary group-hover:text-accent-primary sm:text-xl">
+        <h3 className="type-h3 text-text-primary group-hover:text-accent-primary">
           {item.title}
         </h3>
 
-        <p className="text-sm leading-relaxed text-text-secondary">
+        {/* Clamped: source descriptions vary from one line to a full paragraph,
+            and an unclamped card sets the height of everything beside it. */}
+        <p className="type-body line-clamp-3 text-text-secondary">
           {item.description}
         </p>
       </Link>

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -22,10 +22,10 @@ export default function LearnSection({
   return (
     <section
       id={section.id}
-      className="scroll-mt-24 border-b border-border-primary py-12 last:border-b-0 md:py-16"
+      className="scroll-mt-24 border-b border-border-primary py-16 last:border-b-0 md:py-20"
     >
       {/* Same capped measure as the hero. The rows below stay full width. */}
-      <div className="mb-8 max-w-[950px]">
+      <div className="mb-12 max-w-[950px]">
         {/* The ordinal sits outside the text column so the heading and the
             intro share a left edge. Previously the ordinal pushed only the
             heading across, and the intro hung to the left of its own title. */}
@@ -48,7 +48,7 @@ export default function LearnSection({
         </div>
       </div>
 
-      <ol className="space-y-3">
+      <ol className="space-y-4">
         {section.items.map((item, i) => (
           <LearnItemCard key={item.href} item={item} ordinal={i + 1} />
         ))}

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -29,7 +29,10 @@ export default function LearnSection({
         {/* The ordinal sits outside the text column so the heading and the
             intro share a left edge. Previously the ordinal pushed only the
             heading across, and the intro hung to the left of its own title. */}
-        <div className="flex items-baseline gap-3">
+        {/* The ordinal hangs into the column's left padding at lg and up, so
+            every h2 on the page starts at the same edge — numbered map
+            sections and the unnumbered prose sections alike. */}
+        <div className="flex items-baseline gap-3 lg:-ml-7">
           <span
             aria-hidden="true"
             className="type-eyebrow shrink-0 font-mono text-accent-primary"

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -41,19 +41,21 @@ export default function LearnSection({
         </p>
       </div>
 
-      <ol className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <ol className="space-y-3">
         {section.items.map((item) => (
           <LearnItemCard key={item.href} item={item} />
         ))}
       </ol>
 
-      <Link
-        href={section.more.href}
-        className="type-body mt-6 inline-flex items-center gap-2 font-medium text-accent-primary hover:underline"
-      >
-        {section.more.label}
-        <span aria-hidden="true">→</span>
-      </Link>
+      <div className="mt-6 flex justify-end">
+        <Link
+          href={section.more.href}
+          className="type-caption inline-flex items-center gap-2 rounded-card border border-border-primary px-4 py-2 font-semibold text-text-primary transition-colors hover:border-accent-primary/40 hover:text-accent-primary"
+        >
+          {section.more.label}
+          <span aria-hidden="true">→</span>
+        </Link>
+      </div>
     </section>
   );
 }

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -28,15 +28,15 @@ export default function LearnSection({
         <div className="mb-2 flex items-baseline gap-3">
           <span
             aria-hidden="true"
-            className="font-mono text-sm font-semibold text-accent-primary"
+            className="type-eyebrow font-mono text-accent-primary"
           >
             {section.ordinal}
           </span>
-          <h2 className="text-2xl font-bold text-text-primary md:text-3xl">
+          <h2 className="type-h2 text-text-primary">
             {section.question}
           </h2>
         </div>
-        <p className="text-base leading-relaxed text-text-secondary">
+        <p className="type-body text-text-secondary">
           {section.intro}
         </p>
       </div>
@@ -49,7 +49,7 @@ export default function LearnSection({
 
       <Link
         href={section.more.href}
-        className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-accent-primary hover:underline"
+        className="type-body mt-6 inline-flex items-center gap-2 font-medium text-accent-primary hover:underline"
       >
         {section.more.label}
         <span aria-hidden="true">→</span>

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -26,25 +26,28 @@ export default function LearnSection({
     >
       {/* Same capped measure as the hero. The rows below stay full width. */}
       <div className="mb-8 max-w-[950px]">
-        <div className="mb-2 flex items-baseline gap-3">
+        {/* The ordinal sits outside the text column so the heading and the
+            intro share a left edge. Previously the ordinal pushed only the
+            heading across, and the intro hung to the left of its own title. */}
+        <div className="flex items-baseline gap-3">
           <span
             aria-hidden="true"
-            className="type-eyebrow font-mono text-accent-primary"
+            className="type-eyebrow shrink-0 font-mono text-accent-primary"
           >
             {section.ordinal}
           </span>
-          <h2 className="type-h2 text-text-primary">
-            {section.question}
-          </h2>
+          <div>
+            <h2 className="type-h2 mb-2 text-text-primary">
+              {section.question}
+            </h2>
+            <p className="type-body text-text-secondary">{section.intro}</p>
+          </div>
         </div>
-        <p className="type-body text-text-secondary">
-          {section.intro}
-        </p>
       </div>
 
       <ol className="space-y-3">
-        {section.items.map((item) => (
-          <LearnItemCard key={item.href} item={item} />
+        {section.items.map((item, i) => (
+          <LearnItemCard key={item.href} item={item} ordinal={i + 1} />
         ))}
       </ol>
 

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import LearnItemCard from './LearnItemCard';
+import type { ResolvedLearnSection } from '@/lib/learn-map';
+
+/**
+ * One question in the Learn Map, with the content that answers it in order.
+ *
+ * Server component by design — see the header of `src/lib/learn-map.ts`.
+ *
+ * The heading is a plain <h2> with an anchor id. It is deliberately NOT marked
+ * up as FAQPage Q&A: these are navigation labels with no answer text, and the
+ * page already carries a real FAQ block that the FAQPage schema mirrors.
+ *
+ * Items render as an ordered list because the order is the editorial product —
+ * a grid would read as a catalogue, which is the thing this page replaces.
+ */
+export default function LearnSection({
+  section,
+}: {
+  section: ResolvedLearnSection;
+}) {
+  return (
+    <section
+      id={section.id}
+      className="scroll-mt-24 border-b border-border-primary py-12 last:border-b-0 md:py-16"
+    >
+      <div className="mb-8 max-w-3xl">
+        <div className="mb-2 flex items-baseline gap-3">
+          <span
+            aria-hidden="true"
+            className="font-mono text-sm font-semibold text-accent-primary"
+          >
+            {section.ordinal}
+          </span>
+          <h2 className="text-2xl font-bold text-text-primary md:text-3xl">
+            {section.question}
+          </h2>
+        </div>
+        <p className="text-base leading-relaxed text-text-secondary">
+          {section.intro}
+        </p>
+      </div>
+
+      <ol className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {section.items.map((item) => (
+          <LearnItemCard key={item.href} item={item} />
+        ))}
+      </ol>
+
+      <Link
+        href={section.more.href}
+        className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-accent-primary hover:underline"
+      >
+        {section.more.label}
+        <span aria-hidden="true">→</span>
+      </Link>
+    </section>
+  );
+}

--- a/src/components/learn/LearnSection.tsx
+++ b/src/components/learn/LearnSection.tsx
@@ -24,7 +24,8 @@ export default function LearnSection({
       id={section.id}
       className="scroll-mt-24 border-b border-border-primary py-12 last:border-b-0 md:py-16"
     >
-      <div className="mb-8 max-w-3xl">
+      {/* Same capped measure as the hero. The rows below stay full width. */}
+      <div className="mb-8 max-w-[950px]">
         <div className="mb-2 flex items-baseline gap-3">
           <span
             aria-hidden="true"

--- a/src/components/learn/LearnShell.tsx
+++ b/src/components/learn/LearnShell.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The console shell: page ground, rail column, content column.
+ *
+ * Every page in the learning area uses this, so the rail sits in the same place
+ * and the surfaces read the same everywhere. It replaced five copies of the
+ * same grid class string, which had already started to drift.
+ *
+ * Three surface levels, which is what gives the layout its hierarchy — a single
+ * flat white page makes the rail and the content read as one undifferentiated
+ * sheet:
+ *
+ *   background-tertiary   the ground the console sits on
+ *   background-secondary  the rail column
+ *   background-primary    the content column, the only white surface
+ *
+ * The console is a bounded slab centred on that ground, with an explicit edge
+ * on both sides. Without the edge the rail and the ground read as one — the
+ * left margin vanished into the rail while the right stayed visible, so the
+ * layout looked pushed to one side. The token steps are only 5 units apart, so
+ * the border is doing the work, not the tint.
+ *
+ * Wider than the site's usual max-w-7xl (1280px). The rail costs 260px before
+ * any content, so at 1280 the reading column was narrower than on a page with
+ * no rail at all.
+ */
+export default function LearnShell({
+  sidebar,
+  aside,
+  children,
+}: {
+  sidebar: ReactNode;
+  /** Optional third column — the "On this page" rail on course and lesson pages. */
+  aside?: ReactNode;
+  children: ReactNode;
+}) {
+  // The third column only appears at xl, where there is room for it without
+  // squeezing the reading column.
+  const columns = aside
+    ? 'lg:grid-cols-[260px_minmax(0,1fr)] xl:grid-cols-[260px_minmax(0,1fr)_240px]'
+    : 'lg:grid-cols-[260px_minmax(0,1fr)]';
+
+  return (
+    <div className="bg-background-tertiary">
+      <div
+        className={`mx-auto max-w-[1600px] lg:grid lg:border-x lg:border-border-primary ${columns}`}
+      >
+        <div className="bg-background-secondary lg:border-r lg:border-border-primary">
+          {sidebar}
+        </div>
+
+        <div className="min-w-0 bg-background-primary px-6 lg:px-10">
+          {children}
+        </div>
+
+        {aside && (
+          <div className="hidden bg-background-primary pr-6 xl:block">
+            {aside}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/learn/LearnShell.tsx
+++ b/src/components/learn/LearnShell.tsx
@@ -44,7 +44,7 @@ export default function LearnShell({
   return (
     <div className="learn-console-ground bg-background-console">
       <div
-        className={`mx-auto max-w-[1600px] lg:grid lg:border-x lg:border-border-primary ${columns}`}
+        className={`mx-auto max-w-[1600px] lg:grid lg:border-r lg:border-border-primary ${columns}`}
       >
         <div className="bg-background-rail lg:border-r lg:border-border-primary">
           {sidebar}

--- a/src/components/learn/LearnShell.tsx
+++ b/src/components/learn/LearnShell.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from 'react';
  * sheet:
  *
  *   background-tertiary   the ground the console sits on
- *   background-secondary  the rail column
+ *   background-rail       the rail column, a real step off white
  *   background-primary    the content column, the only white surface
  *
  * The console is a bounded slab centred on that ground, with an explicit edge
@@ -42,11 +42,11 @@ export default function LearnShell({
     : 'lg:grid-cols-[260px_minmax(0,1fr)]';
 
   return (
-    <div className="bg-background-tertiary">
+    <div className="learn-console-ground bg-background-console">
       <div
         className={`mx-auto max-w-[1600px] lg:grid lg:border-x lg:border-border-primary ${columns}`}
       >
-        <div className="bg-background-secondary lg:border-r lg:border-border-primary">
+        <div className="bg-background-rail lg:border-r lg:border-border-primary">
           {sidebar}
         </div>
 

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -1,0 +1,176 @@
+import Link from 'next/link';
+import { guides } from '@/data/guides';
+import categories from '@/data/categories';
+import { prisma } from '@/lib/prisma';
+import { getNewsletters } from '@/data/newsletters';
+
+/**
+ * The rail on the left of /guides. Turns the courses index into the front door
+ * of a learn area rather than a standalone page, and matches the 240px docs
+ * shell already used by /guides/[slug] and /guides/[slug]/[lesson].
+ *
+ * Server component by design — see the header of `src/lib/learn-map.ts`. It
+ * reads `guides` and `categories`, so a 'use client' here would ship both
+ * registries to the browser.
+ *
+ * Topics link straight to the category pages rather than expanding in place.
+ * Those pages already exist and are already indexed, so a link is both simpler
+ * than client-side expansion state and better for search.
+ */
+
+const EXPLORE = [
+  { label: 'Map', href: '/guides', current: true },
+  { label: 'Patterns', href: '/patterns' },
+  { label: 'Skills', href: '/skills' },
+  {
+    label: 'Open source',
+    href: 'https://github.com/imsaif/aiex',
+    external: true,
+  },
+];
+
+/**
+ * Latest issues for the "What's new" group. Published issues live in the
+ * database; the static file covers the gap. The courses page is statically
+ * generated and indexed, so a database blip must never be able to take it
+ * down — same try/catch contract as `src/app/sitemap.ts`.
+ */
+async function getLatestIssues(): Promise<Array<{ slug: string; title: string }>> {
+  try {
+    const drafts = await prisma.newsletterDraft.findMany({
+      where: { status: 'published' },
+      select: { slug: true, title: true },
+      orderBy: { publishDate: 'desc' },
+      take: 3,
+    });
+    if (drafts.length > 0) {
+      return drafts.map((d) => ({ slug: d.slug, title: d.title }));
+    }
+  } catch {
+    // Fall through to the static issues below.
+  }
+  return getNewsletters()
+    .slice(0, 3)
+    .map((n) => ({ slug: n.slug, title: n.title }));
+}
+
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="type-eyebrow mb-3 font-semibold text-text-secondary">
+      {children}
+    </p>
+  );
+}
+
+function RailLink({
+  href,
+  children,
+  current,
+  external,
+}: {
+  href: string;
+  children: React.ReactNode;
+  current?: boolean;
+  external?: boolean;
+}) {
+  const base =
+    'block rounded-card px-3 py-2 type-body transition-colors';
+  const state = current
+    ? 'bg-text-primary text-background-primary font-semibold'
+    : 'text-text-secondary hover:bg-surface-secondary hover:text-text-primary';
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} ${state}`}
+      >
+        {children} <span aria-hidden="true">↗</span>
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className={`${base} ${state}`}
+      aria-current={current ? 'page' : undefined}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default async function LearnSidebar() {
+  const issues = await getLatestIssues();
+
+  return (
+    // Hidden below lg: the map itself is the mobile navigation, and a collapsed
+    // accordion above five sections of content would only push them down.
+    // The rail is also taller than the viewport, so it scrolls inside itself —
+    // without that the Topics group sits below the fold with no way to reach it.
+    <nav
+      aria-label="Learn"
+      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:self-start lg:overflow-y-auto lg:pr-2"
+    >
+      <div className="mb-8">
+        <GroupLabel>Explore</GroupLabel>
+        <ul className="space-y-0.5">
+          {EXPLORE.map((item) => (
+            <li key={item.href}>
+              <RailLink
+                href={item.href}
+                current={item.current}
+                external={item.external}
+              >
+                {item.label}
+              </RailLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mb-8">
+        <GroupLabel>Courses</GroupLabel>
+        <ul className="space-y-0.5">
+          {guides.map((guide) => (
+            <li key={guide.slug}>
+              <RailLink href={`/guides/${guide.slug}`}>{guide.title}</RailLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mb-8">
+        <GroupLabel>What&rsquo;s new</GroupLabel>
+        <ul className="space-y-0.5">
+          {issues.map((issue) => (
+            <li key={issue.slug}>
+              <RailLink href={`/news/${issue.slug}`}>{issue.title}</RailLink>
+            </li>
+          ))}
+          <li>
+            <RailLink href="/news">
+              All <span aria-hidden="true">→</span>
+            </RailLink>
+          </li>
+        </ul>
+      </div>
+
+      <div>
+        <GroupLabel>Topics</GroupLabel>
+        <ul className="space-y-0.5">
+          {categories.map((category) => (
+            <li key={category.slug}>
+              <RailLink href={`/patterns/category/${category.slug}`}>
+                {category.title}
+              </RailLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -186,17 +186,28 @@ function CourseLessons({
 }
 
 export default async function LearnSidebar({
+  active,
   currentGuideSlug,
   currentLessonSlug,
   currentIsOverview,
 }: {
+  /** Which Explore row to mark as the current page. */
+  active?: 'map' | 'patterns' | 'skills';
   /** Set on a course or lesson page so that course opens in the rail. */
   currentGuideSlug?: string;
   currentLessonSlug?: string;
   currentIsOverview?: boolean;
 } = {}) {
   const issues = await getLatestIssues();
-  const onTheMap = !currentGuideSlug;
+  // A course page is inside the map's area but is not the map itself.
+  const activeHref =
+    active === 'patterns'
+      ? '/patterns'
+      : active === 'skills'
+        ? '/skills'
+        : currentGuideSlug
+          ? null
+          : '/guides';
 
   return (
     // Hidden below lg: the map itself is the mobile navigation, and a collapsed
@@ -220,7 +231,7 @@ export default async function LearnSidebar({
             <li key={item.href}>
               <RailLink
                 href={item.href}
-                current={item.href === '/guides' && onTheMap}
+                current={item.href === activeHref}
                 external={item.external}
               >
                 {item.label}

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -220,7 +220,9 @@ export default async function LearnSidebar({
     // keeps the page clean while every group stays reachable.
     <nav
       aria-label="Learn"
-      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:border-r lg:border-border-primary lg:pr-6 lg:pt-10 scrollbar-none"
+      // Border and column background come from LearnShell; the rail only owns
+      // its own padding and scroll behaviour.
+      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:px-4 lg:pt-10 lg:pb-10 scrollbar-none"
     >
       <RailRevealCurrent />
 

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { getNewsletters } from '@/data/newsletters';
 import { getLessonsForCourse } from '@/lib/guides/lesson-urls';
 import { getModuleTitle } from '@/lib/guides/modules';
+import RailRevealCurrent from './RailRevealCurrent';
 
 /**
  * The rail on the left of /guides. Turns the courses index into the front door
@@ -201,14 +202,17 @@ export default async function LearnSidebar({
     // Hidden below lg: the map itself is the mobile navigation, and a collapsed
     // accordion above five sections of content would only push them down.
     //
-    // The rail scrolls with the page rather than inside its own box. It is
-    // taller than the viewport, and a sticky column with overflow-y-auto puts a
-    // second scrollbar on screen — the reference rail has none, and every group
-    // is still reachable by simply scrolling the page.
+    // Pinned, with its own scroll and no visible scrollbar. A rail that scrolls
+    // with the page snaps back to the top on every navigation, because Next
+    // scrolls to top when the route changes — which is what made clicking
+    // through the rail feel jumpy. Sticky keeps it anchored; scrollbar-none
+    // keeps the page clean while every group stays reachable.
     <nav
       aria-label="Learn"
-      className="hidden lg:block lg:border-r lg:border-border-primary lg:pr-6 lg:pt-10"
+      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:border-r lg:border-border-primary lg:pr-6 lg:pt-10 scrollbar-none"
     >
+      <RailRevealCurrent />
+
       <div className="mb-7">
         <GroupLabel>Explore</GroupLabel>
         <ul className="space-y-0.5">
@@ -233,19 +237,43 @@ export default async function LearnSidebar({
             const isCurrent = guide.slug === currentGuideSlug;
             return (
               <li key={guide.slug}>
-                <RailLink
-                  href={`/guides/${guide.slug}`}
-                  current={isCurrent && !currentIsOverview && !currentLessonSlug}
+                {/* A native <details>, so opening a course is a disclosure and
+                    not a navigation. Clicking the row used to load that
+                    course's page, which reset the scroll and made the rail
+                    jump; now it expands in place with no JavaScript and no
+                    route change. "Overview" inside is the link to the course
+                    page itself. */}
+                <details
+                  className="rail-disclosure"
+                  open={isCurrent}
+                  name="learn-rail-course"
                 >
-                  {railLabel(guide.title)}
-                </RailLink>
-                {isCurrent && (
+                  <summary
+                    className={`flex items-center gap-2 rounded-card px-3 py-1.5 type-caption transition-colors ${
+                      isCurrent
+                        ? 'font-semibold text-text-primary'
+                        : 'text-text-secondary hover:bg-surface-secondary hover:text-text-primary'
+                    }`}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className="rail-chevron shrink-0 text-text-secondary"
+                    >
+                      ›
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      {railLabel(guide.title)}
+                    </span>
+                  </summary>
+
                   <CourseLessons
                     guideSlug={guide.slug}
-                    currentLessonSlug={currentLessonSlug}
-                    currentIsOverview={currentIsOverview}
+                    currentLessonSlug={
+                      isCurrent ? currentLessonSlug : undefined
+                    }
+                    currentIsOverview={isCurrent && currentIsOverview}
                   />
-                )}
+                </details>
               </li>
             );
           })}

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -222,7 +222,7 @@ export default async function LearnSidebar({
       aria-label="Learn"
       // Border and column background come from LearnShell; the rail only owns
       // its own padding and scroll behaviour.
-      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-y-auto lg:px-4 lg:pt-10 lg:pb-10 scrollbar-none"
+      className="hidden lg:block lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto lg:px-4 lg:pt-10 lg:pb-10 scrollbar-none"
     >
       <RailRevealCurrent />
 

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -109,11 +109,14 @@ export default async function LearnSidebar() {
   return (
     // Hidden below lg: the map itself is the mobile navigation, and a collapsed
     // accordion above five sections of content would only push them down.
-    // The rail is also taller than the viewport, so it scrolls inside itself —
-    // without that the Topics group sits below the fold with no way to reach it.
+    //
+    // The rail scrolls with the page rather than inside its own box. It is
+    // taller than the viewport, and a sticky column with overflow-y-auto puts a
+    // second scrollbar on screen — the reference rail has none, and every group
+    // is still reachable by simply scrolling the page.
     <nav
       aria-label="Learn"
-      className="hidden lg:block lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:self-start lg:overflow-y-auto lg:pr-2"
+      className="hidden lg:block lg:border-r lg:border-border-primary lg:pr-6"
     >
       <div className="mb-8">
         <GroupLabel>Explore</GroupLabel>

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -3,6 +3,8 @@ import { guides } from '@/data/guides';
 import categories from '@/data/categories';
 import { prisma } from '@/lib/prisma';
 import { getNewsletters } from '@/data/newsletters';
+import { getLessonsForCourse } from '@/lib/guides/lesson-urls';
+import { getModuleTitle } from '@/lib/guides/modules';
 
 /**
  * The rail on the left of /guides. Turns the courses index into the front door
@@ -19,7 +21,7 @@ import { getNewsletters } from '@/data/newsletters';
  */
 
 const EXPLORE = [
-  { label: 'Map', href: '/guides', current: true },
+  { label: 'Map', href: '/guides' },
   { label: 'Patterns', href: '/patterns' },
   { label: 'Skills', href: '/skills' },
   {
@@ -119,8 +121,81 @@ function RailLink({
   );
 }
 
-export default async function LearnSidebar() {
+
+/**
+ * The current course's lessons, nested under it in the Courses group.
+ *
+ * This is what makes the rail a console rather than a page-local nav: the same
+ * groups stay put on every page of the learning area, and the course you are
+ * inside opens in place. Module grouping and the "Overview" row match what the
+ * course pages showed before, so nothing is lost in the merge.
+ */
+function CourseLessons({
+  guideSlug,
+  currentLessonSlug,
+  currentIsOverview,
+}: {
+  guideSlug: string;
+  currentLessonSlug?: string;
+  currentIsOverview?: boolean;
+}) {
+  const lessons = getLessonsForCourse(guideSlug);
+
+  const moduleOrder: string[] = [];
+  const byModule = new Map<string, typeof lessons>();
+  for (const lesson of lessons) {
+    const key = lesson.module || 'lessons';
+    if (!byModule.has(key)) {
+      moduleOrder.push(key);
+      byModule.set(key, []);
+    }
+    byModule.get(key)!.push(lesson);
+  }
+
+  return (
+    <div className="mt-1 ml-3 border-l border-border-primary pl-2">
+      <RailLink href={`/guides/${guideSlug}`} current={currentIsOverview}>
+        Overview
+      </RailLink>
+
+      {moduleOrder.map((moduleKey) => (
+        <div key={moduleKey} className="mt-3">
+          <p className="type-eyebrow mb-1 px-3 font-semibold text-text-secondary">
+            {getModuleTitle(moduleKey)}
+          </p>
+          <ul className="space-y-0.5">
+            {byModule.get(moduleKey)!.map((lesson) => {
+              const slug = lesson.url.split('/').pop() || '';
+              return (
+                <li key={lesson.url}>
+                  <RailLink
+                    href={lesson.url}
+                    current={slug === currentLessonSlug}
+                  >
+                    {lesson.title}
+                  </RailLink>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function LearnSidebar({
+  currentGuideSlug,
+  currentLessonSlug,
+  currentIsOverview,
+}: {
+  /** Set on a course or lesson page so that course opens in the rail. */
+  currentGuideSlug?: string;
+  currentLessonSlug?: string;
+  currentIsOverview?: boolean;
+} = {}) {
   const issues = await getLatestIssues();
+  const onTheMap = !currentGuideSlug;
 
   return (
     // Hidden below lg: the map itself is the mobile navigation, and a collapsed
@@ -141,7 +216,7 @@ export default async function LearnSidebar() {
             <li key={item.href}>
               <RailLink
                 href={item.href}
-                current={item.current}
+                current={item.href === '/guides' && onTheMap}
                 external={item.external}
               >
                 {item.label}
@@ -154,13 +229,26 @@ export default async function LearnSidebar() {
       <div className="mb-7">
         <GroupLabel>Courses</GroupLabel>
         <ul className="space-y-0.5">
-          {guides.map((guide) => (
-            <li key={guide.slug}>
-              <RailLink href={`/guides/${guide.slug}`}>
-                {railLabel(guide.title)}
-              </RailLink>
-            </li>
-          ))}
+          {guides.map((guide) => {
+            const isCurrent = guide.slug === currentGuideSlug;
+            return (
+              <li key={guide.slug}>
+                <RailLink
+                  href={`/guides/${guide.slug}`}
+                  current={isCurrent && !currentIsOverview && !currentLessonSlug}
+                >
+                  {railLabel(guide.title)}
+                </RailLink>
+                {isCurrent && (
+                  <CourseLessons
+                    guideSlug={guide.slug}
+                    currentLessonSlug={currentLessonSlug}
+                    currentIsOverview={currentIsOverview}
+                  />
+                )}
+              </li>
+            );
+          })}
         </ul>
       </div>
 

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -54,9 +54,25 @@ async function getLatestIssues(): Promise<Array<{ slug: string; title: string }>
     .map((n) => ({ slug: n.slug, title: n.title }));
 }
 
+/**
+ * Short label for the rail. Six of the seven course titles end in some form of
+ * "Course for Designers", so at 240px they all wrap to two lines and the rail
+ * loses its rhythm. The group heading already says "Courses", so the suffix is
+ * carrying no information here.
+ *
+ * Presentation only — the full title is unchanged everywhere else, and a title
+ * that does not match simply passes through.
+ */
+function railLabel(title: string): string {
+  return title
+    .replace(/\s+Course for Designers$/i, '')
+    .replace(/\s+Learning Path$/i, '')
+    .replace(/\s+Course$/i, '');
+}
+
 function GroupLabel({ children }: { children: React.ReactNode }) {
   return (
-    <p className="type-eyebrow mb-3 font-semibold text-text-secondary">
+    <p className="type-eyebrow mb-2 px-3 font-semibold text-text-secondary">
       {children}
     </p>
   );
@@ -74,7 +90,7 @@ function RailLink({
   external?: boolean;
 }) {
   const base =
-    'block rounded-card px-3 py-2 type-body transition-colors';
+    'block rounded-card px-3 py-1.5 type-caption transition-colors';
   const state = current
     ? 'bg-text-primary text-background-primary font-semibold'
     : 'text-text-secondary hover:bg-surface-secondary hover:text-text-primary';
@@ -116,9 +132,9 @@ export default async function LearnSidebar() {
     // is still reachable by simply scrolling the page.
     <nav
       aria-label="Learn"
-      className="hidden lg:block lg:border-r lg:border-border-primary lg:pr-6"
+      className="hidden lg:block lg:border-r lg:border-border-primary lg:pr-6 lg:pt-10"
     >
-      <div className="mb-8">
+      <div className="mb-7">
         <GroupLabel>Explore</GroupLabel>
         <ul className="space-y-0.5">
           {EXPLORE.map((item) => (
@@ -135,18 +151,20 @@ export default async function LearnSidebar() {
         </ul>
       </div>
 
-      <div className="mb-8">
+      <div className="mb-7">
         <GroupLabel>Courses</GroupLabel>
         <ul className="space-y-0.5">
           {guides.map((guide) => (
             <li key={guide.slug}>
-              <RailLink href={`/guides/${guide.slug}`}>{guide.title}</RailLink>
+              <RailLink href={`/guides/${guide.slug}`}>
+                {railLabel(guide.title)}
+              </RailLink>
             </li>
           ))}
         </ul>
       </div>
 
-      <div className="mb-8">
+      <div className="mb-7">
         <GroupLabel>What&rsquo;s new</GroupLabel>
         <ul className="space-y-0.5">
           {issues.map((issue) => (

--- a/src/components/learn/LearnSidebar.tsx
+++ b/src/components/learn/LearnSidebar.tsx
@@ -222,7 +222,7 @@ export default async function LearnSidebar({
       aria-label="Learn"
       // Border and column background come from LearnShell; the rail only owns
       // its own padding and scroll behaviour.
-      className="hidden lg:block lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto lg:px-4 lg:pt-10 lg:pb-10 scrollbar-none"
+      className="hidden lg:block lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto lg:px-4 lg:pt-6 lg:pb-10 scrollbar-none"
     >
       <RailRevealCurrent />
 

--- a/src/components/learn/RailRevealCurrent.tsx
+++ b/src/components/learn/RailRevealCurrent.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useLayoutEffect, useEffect } from 'react';
+
+// useLayoutEffect runs before paint, so the rail is already in the right place
+// on first frame. With useEffect the rail painted at scrollTop 0 and then
+// jumped, which is exactly the flicker this is meant to prevent. Falls back to
+// useEffect on the server, where useLayoutEffect warns and does nothing.
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * Scrolls the rail so the current item is visible.
@@ -20,7 +27,7 @@ import { useEffect } from 'react';
  * behaviour people expect when opening a lesson.
  */
 export default function RailRevealCurrent() {
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const rail = document.querySelector<HTMLElement>('nav[aria-label="Learn"]');
     const current = rail?.querySelector<HTMLElement>('[aria-current="page"]');
     if (!rail || !current) return;

--- a/src/components/learn/RailRevealCurrent.tsx
+++ b/src/components/learn/RailRevealCurrent.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Scrolls the rail so the current item is visible.
+ *
+ * The rail is pinned with its own scroll, and on a long course it is several
+ * times taller than the viewport — so on a deep lesson the highlighted row
+ * would start below the fold and you would have to hunt for your place.
+ *
+ * Deliberately data-free: it reads the DOM for `[aria-current="page"]` and
+ * imports nothing. The rail's server components pull in the guide and pattern
+ * registries, and a client component anywhere in that tree would ship them to
+ * the browser — see the header of `src/lib/learn-map.ts`. This one is safe
+ * precisely because it knows nothing.
+ *
+ * Scrolls the container directly rather than calling scrollIntoView, which
+ * would also move the page and undo the "start at the top of the article"
+ * behaviour people expect when opening a lesson.
+ */
+export default function RailRevealCurrent() {
+  useEffect(() => {
+    const rail = document.querySelector<HTMLElement>('nav[aria-label="Learn"]');
+    const current = rail?.querySelector<HTMLElement>('[aria-current="page"]');
+    if (!rail || !current) return;
+
+    // Measured from rects, not offsetTop: the rail is position:sticky, which
+    // makes it the offsetParent for its own children, so subtracting the
+    // rail's own offsetTop double-counts and lands on zero.
+    const railRect = rail.getBoundingClientRect();
+    const currentRect = current.getBoundingClientRect();
+    const delta =
+      currentRect.top - railRect.top - rail.clientHeight / 2 + currentRect.height / 2;
+
+    rail.scrollTop = Math.max(0, rail.scrollTop + delta);
+  }, []);
+
+  return null;
+}

--- a/src/components/skills/SkillsDirectory.tsx
+++ b/src/components/skills/SkillsDirectory.tsx
@@ -41,48 +41,42 @@ export function SkillsDirectory({ rows, categories }: SkillsDirectoryProps) {
   }, [rows, searchQuery, selectedCategory]);
 
   return (
-    <div className="flex flex-col lg:flex-row gap-8">
-      {/* Sidebar (stacks above the grid on mobile, fixed rail on desktop) */}
-      <aside className="lg:w-64 flex-shrink-0">
-        <div className="bg-surface-primary dark:bg-surface-elevated rounded-2xl p-6 border border-border-primary shadow-card lg:sticky lg:top-24">
-          <h3 className="font-semibold text-xl mb-4 text-text-primary">Categories</h3>
-          <ul className="space-y-2">
-            <li>
-              <button
-                type="button"
-                onClick={() => setSelectedCategory('All Skills')}
-                aria-pressed={selectedCategory === 'All Skills'}
-                className={`w-full text-left px-3 py-2 rounded-lg transition-all ${
-                  selectedCategory === 'All Skills'
-                    ? 'bg-white font-semibold shadow-sm text-black'
-                    : 'hover:bg-white text-gray-700 dark:text-white hover:text-black'
-                }`}
-              >
-                All Skills
-              </button>
-            </li>
-            {categories.map((category) => (
-              <li key={category}>
-                <button
-                  type="button"
-                  onClick={() => setSelectedCategory(category)}
-                  aria-pressed={selectedCategory === category}
-                  className={`w-full text-left px-3 py-2 rounded-lg transition-all ${
-                    selectedCategory === category
-                      ? 'bg-white font-semibold shadow-sm text-black'
-                      : 'hover:bg-white text-gray-700 dark:text-white hover:text-black'
-                  }`}
-                >
-                  {category}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </aside>
+    <div>
+      {/* Categories as a horizontal filter row rather than a left column, the
+          same as /patterns. Inside the console that column sat beside the rail,
+          so the page had two nav columns before the first card. */}
+      <div className="mb-8 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => setSelectedCategory('All Skills')}
+          aria-pressed={selectedCategory === 'All Skills'}
+          className={`type-caption rounded-pill border px-4 py-2 transition-colors ${
+            selectedCategory === 'All Skills'
+              ? 'border-transparent bg-text-primary font-semibold text-background-primary'
+              : 'border-border-primary text-text-secondary hover:border-accent-primary/40 hover:text-text-primary'
+          }`}
+        >
+          All Skills
+        </button>
+        {categories.map((category) => (
+          <button
+            key={category}
+            type="button"
+            onClick={() => setSelectedCategory(category)}
+            aria-pressed={selectedCategory === category}
+            className={`type-caption rounded-pill border px-4 py-2 transition-colors ${
+              selectedCategory === category
+                ? 'border-transparent bg-text-primary font-semibold text-background-primary'
+                : 'border-border-primary text-text-secondary hover:border-accent-primary/40 hover:text-text-primary'
+            }`}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
 
       {/* Skills Grid */}
-      <div className="flex-1">
+      <div>
         {/* Search Bar */}
         <div className="mb-6 bg-surface-primary dark:bg-surface-elevated rounded-2xl p-5 border border-border-primary shadow-card">
           <UnifiedSearchBar

--- a/src/components/ui/LessonRenderer.tsx
+++ b/src/components/ui/LessonRenderer.tsx
@@ -192,7 +192,7 @@ function CopyButton({ code }: { code: string }) {
       type="button"
       onClick={handleCopy}
       aria-label={copied ? 'Copied to clipboard' : 'Copy code to clipboard'}
-      className="absolute top-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium cursor-pointer transition-all border bg-gray-800/90 dark:bg-gray-700/90 text-white border-gray-700 dark:border-gray-600 hover:bg-gray-800 dark:hover:bg-gray-700"
+      className="absolute top-3 right-3 inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium cursor-pointer transition-all border bg-surface-secondary text-text-primary border-border-primary hover:bg-surface-secondary dark:hover:bg-surface-secondary"
     >
       {copied ? (
         <>
@@ -210,19 +210,19 @@ function CodePreviewBlock({ section }: { section: { code: string; language?: str
   const [showCode, setShowCode] = useState(false);
 
   return (
-    <div className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+    <div className="mb-6 rounded-lg border border-border-primary overflow-hidden">
       {/* Toggle header */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
-        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-surface-secondary border-b border-border-primary">
+        <span className="text-sm font-medium text-text-secondary">
           {section.label || 'Example'}
         </span>
-        <div className="inline-flex rounded-md border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 p-0.5">
+        <div className="inline-flex rounded-md border border-border-primary bg-surface-secondary p-0.5">
           <button
             onClick={() => setShowCode(false)}
             className={`flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-all cursor-pointer ${
               !showCode
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 shadow-sm'
-                : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                ? 'bg-accent-primary text-text-on-accent shadow-sm'
+                : 'text-text-secondary hover:text-text-primary dark:hover:text-text-primary'
             }`}
           >
             <EyeIcon className="w-3.5 h-3.5" />
@@ -232,8 +232,8 @@ function CodePreviewBlock({ section }: { section: { code: string; language?: str
             onClick={() => setShowCode(true)}
             className={`flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-all cursor-pointer ${
               showCode
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 shadow-sm'
-                : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                ? 'bg-accent-primary text-text-on-accent shadow-sm'
+                : 'text-text-secondary hover:text-text-primary dark:hover:text-text-primary'
             }`}
           >
             <CodeBracketIcon className="w-3.5 h-3.5" />
@@ -245,18 +245,18 @@ function CodePreviewBlock({ section }: { section: { code: string; language?: str
       {/* Content */}
       {showCode ? (
         <div className="relative">
-          <pre className="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-4 m-0 overflow-auto font-mono text-sm max-h-[500px]">
+          <pre className="bg-surface-primary text-text-primary p-4 m-0 overflow-auto font-mono text-sm max-h-[500px]">
             <code>{section.code}</code>
           </pre>
           <button
             onClick={() => navigator.clipboard.writeText(section.code)}
-            className="absolute top-3 right-3 bg-gray-800/80 dark:bg-gray-700/80 border border-gray-700 dark:border-gray-600 text-white px-3 py-1.5 rounded text-xs font-medium cursor-pointer transition-all hover:bg-gray-800 dark:hover:bg-gray-700"
+            className="absolute top-3 right-3 bg-surface-secondary border border-border-primary text-text-primary px-3 py-1.5 rounded text-xs font-medium cursor-pointer transition-all hover:bg-surface-secondary dark:hover:bg-surface-secondary"
           >
             Copy
           </button>
         </div>
       ) : (
-        <div className="p-4 bg-gray-50/50 dark:bg-gray-900/30">
+        <div className="p-4 bg-surface-secondary">
           <DynamicPreview previewId={section.previewId} />
         </div>
       )}
@@ -442,7 +442,7 @@ const renderSection = (
           <h2
             key={index}
             id={id}
-            className="scroll-mt-24 text-[1.75rem] font-bold text-text-primary mt-14 mb-5 pb-3 border-b border-border-primary"
+            className="type-h2 scroll-mt-24 text-text-primary mt-14 mb-5 border-t border-border-primary pt-10"
           >
             {section.content}
           </h2>
@@ -453,7 +453,7 @@ const renderSection = (
           <h3
             key={index}
             id={id}
-            className="scroll-mt-24 text-[1.375rem] font-bold text-text-primary mt-10 mb-4"
+            className="type-h3 scroll-mt-24 text-text-primary mt-10 mb-4 border-t border-border-primary pt-8"
           >
             {section.content}
           </h3>
@@ -464,7 +464,7 @@ const renderSection = (
           <h4
             key={index}
             id={id}
-            className="scroll-mt-24 text-[1.125rem] font-semibold text-text-secondary mt-8 mb-4"
+            className="scroll-mt-24 type-lead font-semibold text-text-secondary mt-8 mb-4"
           >
             {section.content}
           </h4>
@@ -533,10 +533,10 @@ const renderSection = (
               className={`p-5 ${CARD_SHELL}`}
             >
               <div className="flex gap-3 mb-4">
-                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-semibold text-sm flex-shrink-0">
+                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-accent-primary text-text-on-accent font-semibold text-sm flex-shrink-0">
                   {step.number}
                 </div>
-                <h4 className="m-0 font-bold text-gray-900 dark:text-gray-100 text-[1.125rem]">
+                <h4 className="m-0 font-bold text-text-primary type-lead">
                   {step.title}
                 </h4>
               </div>
@@ -636,13 +636,13 @@ const renderSection = (
     case 'code':
       return (
         <div key={index} className="mb-6">
-          <div className="bg-gray-900 dark:bg-gray-950 text-white px-4 py-3 rounded-t-lg">
+          <div className="bg-text-primary text-background-primary px-4 py-3 rounded-t-lg">
             <span className="text-sm font-mono">
               {section.label || section.language || 'code'}
             </span>
           </div>
           <div className="relative">
-            <pre className="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-4 m-0 rounded-b-lg border border-gray-200 dark:border-gray-700 border-t-0 overflow-auto font-mono text-sm">
+            <pre className="bg-surface-primary text-text-primary p-4 m-0 rounded-b-lg border border-border-primary border-t-0 overflow-auto font-mono text-sm">
               <code>{section.code}</code>
             </pre>
             <CopyButton code={section.code} />
@@ -683,18 +683,18 @@ const renderSection = (
                 />
               )}
               {section.label && (
-                <figcaption className="p-3 text-gray-500 dark:text-gray-400 text-sm">
+                <figcaption className="p-3 text-text-secondary text-sm">
                   {section.label}
                 </figcaption>
               )}
             </figure>
           ) : (
-            <div className="rounded-lg border-2 border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 p-12 text-center">
-              <div className="text-gray-400 dark:text-gray-500 mb-2">{getIcon('github')}</div>
-              <p className="m-0 mb-2 text-gray-600 dark:text-gray-400 font-semibold">
+            <div className="rounded-lg border-2 border-dashed border-border-primary bg-surface-secondary p-12 text-center">
+              <div className="text-text-secondary mb-2">{getIcon('github')}</div>
+              <p className="m-0 mb-2 text-text-secondary font-semibold">
                 {section.label || 'Image coming soon'}
               </p>
-              <p className="m-0 text-gray-400 dark:text-gray-500 text-sm">Add image here</p>
+              <p className="m-0 text-text-secondary text-sm">Add image here</p>
             </div>
           )}
         </div>
@@ -708,15 +708,15 @@ const renderSection = (
           className="mt-14 p-6 bg-background-secondary border border-border-secondary rounded-card"
         >
           <div className="flex gap-3 mb-4">
-            <CheckCircleIcon className="w-6 h-6 text-green-500 flex-shrink-0" />
-            <h3 className="m-0 text-xl font-bold text-gray-900 dark:text-gray-100">
+            <CheckCircleIcon className="w-6 h-6 text-status-success flex-shrink-0" />
+            <h3 className="m-0 text-xl font-bold text-text-primary">
               {section.title}
             </h3>
           </div>
           <ul className="m-0 mb-4 p-0 list-none text-text-secondary">
             {section.items.map((item, i) => (
               <li key={i} className="mb-2 flex gap-2">
-                <CheckIcon className="w-5 h-5 text-green-500 flex-shrink-0" />
+                <CheckIcon className="w-5 h-5 text-status-success flex-shrink-0" />
                 {item}
               </li>
             ))}

--- a/src/data/__tests__/learn-map.test.ts
+++ b/src/data/__tests__/learn-map.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { guides } from '@/data/guides';
+import { learnMap } from '@/data/learn-map';
+import { resolveLearnItem } from '@/lib/learn-map';
+
+/**
+ * The Learn Map stores references, not content, so a renamed or deleted piece of
+ * content shows up here as a red test rather than as a card linking to a 404.
+ *
+ * The resolver itself throws on an unresolvable reference — that is the real gate,
+ * since /guides is statically generated and the build fails with the slug named.
+ * These assertions exist so the failure arrives in seconds instead of at build.
+ */
+describe('learn map', () => {
+  const allItems = learnMap.flatMap((section) => section.items);
+
+  it('resolves every reference to real content', () => {
+    for (const item of allItems) {
+      expect(() => resolveLearnItem(item)).not.toThrow();
+    }
+  });
+
+  it('never links to the same page twice', () => {
+    const hrefs = allItems.map((item) => resolveLearnItem(item).href);
+    const duplicates = hrefs.filter((href, i) => hrefs.indexOf(href) !== i);
+    expect(duplicates).toEqual([]);
+  });
+
+  it('points every resource at a route that exists on disk', () => {
+    for (const item of allItems) {
+      if (item.kind !== 'resource') continue;
+      const routeDir = path.join(process.cwd(), 'src/app', item.href);
+      expect(fs.existsSync(path.join(routeDir, 'page.tsx'))).toBe(true);
+    }
+  });
+
+  it('gives every section a unique id and at least one item', () => {
+    const ids = learnMap.map((section) => section.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const section of learnMap) {
+      expect(section.items.length).toBeGreaterThan(0);
+      expect(section.more.href.startsWith('/')).toBe(true);
+    }
+  });
+
+  /**
+   * The map is an editorial recommendation. Featuring a course that is still
+   * marked work-in-progress sends people at unfinished content.
+   */
+  it('only features courses that are ready', () => {
+    const notReady = allItems
+      .filter((item) => item.kind === 'course')
+      .map((item) => guides.find((g) => g.slug === (item as { slug: string }).slug))
+      .filter((guide) => guide && guide.status !== 'ready')
+      .map((guide) => guide!.slug);
+
+    expect(notReady).toEqual([]);
+  });
+});

--- a/src/data/learn-map.ts
+++ b/src/data/learn-map.ts
@@ -73,6 +73,13 @@ export const learnMap: LearnSection[] = [
       { kind: 'pattern', slug: 'progressive-disclosure' },
       { kind: 'pattern', slug: 'human-in-the-loop' },
       { kind: 'pattern', slug: 'error-recovery' },
+      {
+        kind: 'resource',
+        href: '/handbook',
+        title: 'The AI UX Handbook',
+        badge: 'Kit',
+        blurb: 'The patterns written up as chapters, if you would rather read straight through.',
+      },
     ],
     more: { label: 'All 38 patterns', href: '/patterns' },
   },
@@ -165,9 +172,18 @@ export const learnMap: LearnSection[] = [
         badge: 'Checklist',
         blurb: 'Where AI interfaces commonly fail assistive technology, and what to do instead.',
       },
+      {
+        kind: 'resource',
+        href: '/toolkit',
+        title: 'AI Interaction Toolkit',
+        badge: 'Kit',
+        blurb: 'Interaction patterns, component specs and implementation checklists as a PDF.',
+      },
       { kind: 'pattern', slug: 'vulnerable-user-protection' },
       { kind: 'pattern', slug: 'universal-access-patterns' },
     ],
-    more: { label: 'The full toolkit', href: '/toolkit' },
+    // Points at /resources now that it is off the nav — the page still exists
+    // and still ranks, so the map is how you get to it.
+    more: { label: 'Every tool and download', href: '/resources' },
   },
 ];

--- a/src/data/learn-map.ts
+++ b/src/data/learn-map.ts
@@ -1,0 +1,173 @@
+/**
+ * The Learn Map — the curated structure behind /guides.
+ *
+ * Sections are labelled by the visitor's question rather than by level or topic.
+ * Under each one sits a hand-ordered mix of existing content. Order is the
+ * editorial product and is never sorted at runtime.
+ *
+ * This file stores REFERENCES, not content. An item names a kind and a slug;
+ * title, description and read time are resolved at build time from the existing
+ * registries by `resolveLearnItem` in `src/lib/learn-map.ts`. That is deliberate:
+ * the map cannot drift from the content, and renaming a pattern fails the build
+ * rather than leaving a stale card behind.
+ *
+ * Every href here points at a page that already exists and is already indexed.
+ * The map creates internal links; it never creates destinations.
+ */
+
+/** The kinds actually in use. Adding one is a two-line change here plus a
+ *  resolver branch — don't declare kinds ahead of need. */
+export type LearnItemKind = 'course' | 'pattern' | 'resource';
+
+/** Registry-backed. Title, description and read time come from the source. */
+export interface RegistryRef {
+  kind: 'course' | 'pattern';
+  /** Guide.slug or Pattern.slug */
+  slug: string;
+  /** Editorial override; falls back to the source description. */
+  blurb?: string;
+}
+
+/**
+ * The escape hatch, made visible in the type rather than hidden behind optional
+ * fields. The checklists and kits are hand-built pages with no data registry,
+ * and inventing one for three items would cost more than it saves.
+ */
+export interface ResourceRef {
+  kind: 'resource';
+  /** Absolute path to an existing route. */
+  href: string;
+  title: string;
+  badge: 'Kit' | 'Checklist';
+  blurb: string;
+}
+
+export type LearnItemRef = RegistryRef | ResourceRef;
+
+export interface LearnSection {
+  /** Stable anchor id. Used for #links and scroll-mt. */
+  id: string;
+  /** Two-digit ordinal shown before the question, as on the reference. */
+  ordinal: string;
+  /** The visitor's question. Rendered as an <h2>. Never marked up as FAQ Q&A. */
+  question: string;
+  /** One short paragraph, plain text. */
+  intro: string;
+  items: LearnItemRef[];
+  more: { label: string; href: string };
+}
+
+export const learnMap: LearnSection[] = [
+  {
+    id: 'first-ai-feature',
+    ordinal: '01',
+    question: "I'm designing my first AI feature. Where do I start?",
+    // TODO(copy): replace with Imran's words before this ships.
+    intro:
+      'The usual UX playbook assumes the system does what you told it to. Start ' +
+      'with what changes when it does not, and the handful of patterns you will ' +
+      'reach for in the first week.',
+    items: [
+      { kind: 'course', slug: 'ai-ux-skills-guide' },
+      { kind: 'pattern', slug: 'conversational-ui' },
+      { kind: 'pattern', slug: 'progressive-disclosure' },
+      { kind: 'pattern', slug: 'human-in-the-loop' },
+      { kind: 'pattern', slug: 'error-recovery' },
+    ],
+    more: { label: 'All 38 patterns', href: '/patterns' },
+  },
+  {
+    id: 'trust',
+    ordinal: '02',
+    question: 'How do I make people trust what the AI tells them?',
+    // TODO(copy): replace with Imran's words before this ships.
+    intro:
+      'Most AI features fail on confidence, not capability. These cover showing ' +
+      'uncertainty, explaining a decision, and leaving people a way back when it ' +
+      'gets something wrong.',
+    items: [
+      { kind: 'pattern', slug: 'confidence-visualization' },
+      { kind: 'pattern', slug: 'explainable-ai' },
+      { kind: 'pattern', slug: 'trust-calibration' },
+      { kind: 'pattern', slug: 'intent-preview' },
+      { kind: 'pattern', slug: 'action-audit-trail' },
+    ],
+    more: {
+      label: 'More trustworthy AI patterns',
+      href: '/patterns/category/trustworthy-reliable-ai',
+    },
+  },
+  {
+    id: 'conversation',
+    ordinal: '03',
+    question: 'How do I design the conversation itself?',
+    // TODO(copy): replace with Imran's words before this ships.
+    intro:
+      'Turn-taking, memory, and knowing when to hand back to a person. The course ' +
+      'covers the shape of a conversation end to end; the patterns are the ' +
+      'decisions inside it.',
+    items: [
+      { kind: 'course', slug: 'conversational-ui-guide' },
+      { kind: 'pattern', slug: 'mixed-initiative-control' },
+      { kind: 'pattern', slug: 'graceful-handoff' },
+      { kind: 'pattern', slug: 'selective-memory' },
+      { kind: 'pattern', slug: 'session-degradation-prevention' },
+    ],
+    more: {
+      label: 'More natural interaction patterns',
+      href: '/patterns/category/natural-interaction',
+    },
+  },
+  {
+    id: 'build-it',
+    ordinal: '04',
+    question: 'How do I get AI tools to build what I designed?',
+    // TODO(copy): replace with Imran's words before this ships.
+    intro:
+      'Five hands-on paths for the tools that turn a design into working code. ' +
+      'Pick the one you already have open — they do not need to be taken in order.',
+    items: [
+      { kind: 'course', slug: 'claude-code-learning-path' },
+      { kind: 'course', slug: 'claude-design-learning-path' },
+      { kind: 'course', slug: 'cursor-learning-path' },
+      { kind: 'course', slug: 'github-copilot-learning-path' },
+      { kind: 'course', slug: 'github-learning-path' },
+    ],
+    more: { label: 'Prompts for every pattern', href: '/prompts' },
+  },
+  {
+    id: 'check-your-work',
+    ordinal: '05',
+    question: 'How do I check my work before it ships?',
+    // TODO(copy): replace with Imran's words before this ships.
+    intro:
+      'Run the design past something other than your own judgement. Two ' +
+      'checklists, an audit kit, and the patterns that catch what checklists miss.',
+    items: [
+      {
+        kind: 'resource',
+        href: '/agent-readability-audit-kit',
+        title: 'Agent Readability Audit Kit',
+        badge: 'Kit',
+        blurb: 'Check whether an AI agent can actually read and act on your interface.',
+      },
+      {
+        kind: 'resource',
+        href: '/agentic-ux-checklist',
+        title: 'Agentic UX Checklist',
+        badge: 'Checklist',
+        blurb: 'The pass to make before shipping anything that acts on a user’s behalf.',
+      },
+      {
+        kind: 'resource',
+        href: '/accessibility-checklist-for-ai-designs',
+        title: 'Accessibility Checklist for AI Designs',
+        badge: 'Checklist',
+        blurb: 'Where AI interfaces commonly fail assistive technology, and what to do instead.',
+      },
+      { kind: 'pattern', slug: 'vulnerable-user-protection' },
+      { kind: 'pattern', slug: 'universal-access-patterns' },
+    ],
+    more: { label: 'The full toolkit', href: '/toolkit' },
+  },
+];

--- a/src/lib/cross-links.ts
+++ b/src/lib/cross-links.ts
@@ -2,12 +2,12 @@
  * Bidirectional cross-links between guides and patterns.
  *
  * Used to create internal link equity between indexed pattern pages and
- * new lesson pages, accelerating Google's crawl of the ~66 lesson URLs
+ * new lesson pages, accelerating Google's crawl of the ~84 lesson URLs
  * shipped in the Apr 2026 SEO refactor.
  */
 
 /** Guide slug → related pattern slugs (semantically curated). Every pattern
- *  in the 36-pattern catalogue must appear in at least one entry below so the
+ *  in the 38-pattern catalogue must appear in at least one entry below so the
  *  pattern detail page renders a "Practice in Courses" cross-link card. */
 const GUIDE_TO_PATTERNS: Record<string, string[]> = {
   'claude-code-learning-path': [

--- a/src/lib/learn-map.ts
+++ b/src/lib/learn-map.ts
@@ -1,0 +1,83 @@
+/**
+ * Resolves Learn Map references to renderable data.
+ *
+ * SERVER ONLY — this module pulls in the full pattern registry (38 modules) and
+ * `src/data/guides.ts` (421 KB). It must never appear in a module graph reachable
+ * from a `'use client'` boundary. Map components carry no `'use client'`
+ * directive; any client leaf receives resolved primitives as props, never a
+ * `Pattern`, `Guide` or `LearnSection` object. Copy that quotes a pattern count
+ * uses `PATTERN_COUNT` from `@/data/pattern-count`, never `patterns.length`.
+ *
+ * Unresolvable references THROW rather than rendering a placeholder card. /guides
+ * is statically generated, so a dead slug fails the build with the slug named.
+ */
+
+import { guides, getGuideBySlug } from '@/data/guides';
+import patterns from '@/data/patterns';
+import type { LearnItemRef, LearnSection } from '@/data/learn-map';
+
+export interface ResolvedLearnItem {
+  href: string;
+  title: string;
+  description: string;
+  /** 'Course' | 'Pattern' | 'Kit' | 'Checklist' */
+  badge: string;
+  /**
+   * Minutes. Usually absent: only Guide.readTime and GuideLesson.duration exist
+   * in the data. Patterns have no read time and inventing one would be exactly
+   * the drift that reference-by-slug exists to prevent.
+   */
+  readTime?: number;
+  /** Lesson count, courses only. */
+  lessonCount?: number;
+}
+
+export interface ResolvedLearnSection extends Omit<LearnSection, 'items'> {
+  items: ResolvedLearnItem[];
+}
+
+export function resolveLearnItem(ref: LearnItemRef): ResolvedLearnItem {
+  if (ref.kind === 'resource') {
+    return {
+      href: ref.href,
+      title: ref.title,
+      description: ref.blurb,
+      badge: ref.badge,
+    };
+  }
+
+  if (ref.kind === 'course') {
+    const guide = getGuideBySlug(ref.slug);
+    if (!guide) {
+      throw new Error(`learn-map: unknown course slug "${ref.slug}"`);
+    }
+    return {
+      href: `/guides/${guide.slug}`,
+      title: guide.title,
+      description: ref.blurb ?? guide.excerpt ?? guide.description,
+      badge: 'Course',
+      readTime: guide.readTime,
+      lessonCount: guide.lessonCount ?? guide.lessons?.length,
+    };
+  }
+
+  const pattern = patterns.find((p) => p.slug === ref.slug);
+  if (!pattern) {
+    throw new Error(`learn-map: unknown pattern slug "${ref.slug}"`);
+  }
+  return {
+    href: `/patterns/${pattern.slug}`,
+    title: pattern.title,
+    description: ref.blurb ?? pattern.description,
+    badge: 'Pattern',
+  };
+}
+
+export function resolveLearnSection(section: LearnSection): ResolvedLearnSection {
+  return { ...section, items: section.items.map(resolveLearnItem) };
+}
+
+/** Every course, for the "All courses" section below the map. */
+export function allCourses() {
+  return guides;
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -13,6 +13,8 @@ export default {
           secondary: 'var(--background-secondary)',
           tertiary: 'var(--background-tertiary)',
           grain: 'var(--background-grain)',
+          console: 'var(--background-console)',
+          rail: 'var(--background-rail)',
         },
         surface: {
           primary: 'var(--surface-primary)',

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -26,6 +26,10 @@ export default {
           tertiary: 'var(--text-tertiary)',
           disabled: 'var(--text-disabled)',
           error: 'var(--text-error)',
+          // Text sitting on an accent-primary fill. accent-primary inverts
+          // between themes, so this has to invert with it — call sites were
+          // hand-rolling `text-white dark:text-gray-900` instead.
+          'on-accent': 'var(--text-on-accent)',
         },
         // Minimal accent colors for interactive elements
         accent: {


### PR DESCRIPTION
Restructures `/guides` from a flat grid of course cards into a question-led **Learn Map**, modelled on `aihero.dev/learn`, and extends the same console shell across the learning area.

## What changed

**The map.** Five sections labelled by the visitor's question, each holding a hand-ordered mix of courses, patterns and kits. The map stores *references*, not content — an item names a kind and a slug, and title, description and read time resolve at build time from the existing registries. An unresolvable reference throws, so a renamed pattern fails the build rather than shipping a dead card.

**The console.** One shared shell (`LearnShell`) across `/guides`, `/patterns`, `/skills`, and the course and lesson pages — it replaced five copies of the same grid string, which had already drifted. The rail lists Explore, all 7 courses, the latest newsletter issues and the 8 pattern categories, and the current course opens in place via native `<details>`: expand and collapse with no route change and no JavaScript.

**Navigation.** Top bar is now Tool · Courses · News · Saved, pinned, and 61px tall (was 83). "Patterns & Skills" came out because the rail carries them; "Resources" came out because seven of its ten entries were reachable elsewhere — `/toolkit` and `/handbook` moved into the map, and the page itself stays.

**Type and surfaces.** No raw font sizes left on `/guides` or in the map components. Added two tokens the system was missing: `--type-lead` (the scale stepped 24px straight to 16px) and `--text-on-accent` (every call site was hand-rolling `text-white dark:text-gray-900`).

## SEO — nothing lost

Measured before and after on every page touched:

- No page link lost anywhere. All 7 course links, all 84 lesson URLs and all 38 pattern URLs still resolve.
- `#why-guides` (252 words) and the FAQ kept — both are indexed content on ranking pages.
- JSON-LD block counts unchanged on `/guides`, `/patterns`, `/skills`, and the course and lesson pages.
- `src/app/sitemap.ts` and `next.config.mjs` untouched. No route added, renamed or redirected.

Two deliberate changes worth knowing: the `/guides` H1 is now a question rather than a keyword phrase (title, description and canonical unchanged, and the tool keywords still appear throughout the body), and the rail adds internal links, so `/patterns` went from 70 to 171.

## Before merging

- **The five section intros are draft copy**, marked `TODO(copy)` in `src/data/learn-map.ts`. They need Imran's words.
- **`LessonRenderer` was migrated off 19 raw greys.** Not optional — the brand validator scans whole staged files, so the lesson separators could not be committed while those sat in the code-block markup. The mapping is conservative and the file is now token-clean, but it changes how code blocks and image placeholders render across all 84 lessons. Worth opening one lesson with a code block.

## Verification

`npx tsc --noEmit` clean on every changed file. Jest: 153 passing; the one failure (`pattern-page-structure`) fails identically on `master`. A new `learn-map` test asserts every reference resolves, no href appears twice, every resource route exists on disk, and no work-in-progress course is featured — force-added, since `.gitignore` excludes `**/__tests__/`.

https://claude.ai/code/session_01Qs6JfMDQnqgG8y9MmCkq8j
